### PR TITLE
chore(renovate): add commit message customization for PR titles

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,19 @@
 {
 	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
-	"extends": [
-		"config:recommended"
+	"extends": ["config:recommended"],
+	"packageRules": [
+		{
+			"matchUpdateTypes": ["major"],
+			"commitMessagePrefix": "⚠️ chore(deps)!: ",
+			"commitMessageAction": "update dependency",
+			"commitMessageTopic": "{{depName}}",
+			"commitMessageExtra": "to v{{newVersion}}"
+		},
+		{
+			"commitMessagePrefix": "chore(deps): ",
+			"commitMessageAction": "update dependency",
+			"commitMessageTopic": "{{depName}}",
+			"commitMessageExtra": "to v{{newVersion}}"
+		}
 	]
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Standardized Renovate commit messages and PR titles for dependency updates. Major bumps now include a breaking-change marker to make them easy to spot.

- **New Features**
  - Custom templates for majors: "⚠️ chore(deps)!: update dependency {{depName}} to v{{newVersion}}"
  - Custom templates for others: "chore(deps): update dependency {{depName}} to v{{newVersion}}"

<sup>Written for commit a8e63b5dc0139f5091bd2d23d5c36f74c8c8f2a5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

