### PR TITLE
chore(renovate): add automerge to updateTypes patch

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,19 +1,19 @@
 {
 	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
 	"extends": ["config:recommended"],
+	"commitMessagePrefix": "chore(deps): ",
+	"commitMessageAction": "update dependency",
+	"commitMessageTopic": "{{depName}}",
+	"commitMessageExtra": "to v{{newVersion}}",
 	"packageRules": [
 		{
 			"matchUpdateTypes": ["major"],
-			"commitMessagePrefix": "⚠️ chore(deps)!: ",
-			"commitMessageAction": "update dependency",
-			"commitMessageTopic": "{{depName}}",
-			"commitMessageExtra": "to v{{newVersion}}"
+			"commitMessagePrefix": "⚠️ chore(deps)!: "
 		},
 		{
-			"commitMessagePrefix": "chore(deps): ",
-			"commitMessageAction": "update dependency",
-			"commitMessageTopic": "{{depName}}",
-			"commitMessageExtra": "to v{{newVersion}}"
+			"matchUpdateTypes": ["patch"],
+			"automerge": true,
+			"automergeType": "pr"
 		}
 	]
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Enable Renovate to automerge patch updates via PRs to reduce noise and speed routine dependency bumps. Standardize commit messages at the root; major updates still use the breaking-change prefix (⚠️ chore(deps)!:).

<sup>Written for commit e98f8b2eeab6786c76ad565fedfdb90f72eb93d8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

