### PR TITLE
chore(renovate): add minimumReleaseAge

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,8 @@
 {
 	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
 	"extends": ["config:recommended"],
-	"rangeStrategy": "pin"
+	"rangeStrategy": "pin",
+	"minimumReleaseAge": "30 days",
+	"prCreation": "not-pending",
+	"dependencyDashboard": true
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated Renovate config to only propose dependency updates that are at least 30 days old to reduce churn and risky upgrades. Enabled the dependency dashboard and set PR creation to not-pending to avoid PRs while checks are pending.

<sup>Written for commit def703a6c35b7403c85d8c27686b532e30427c3f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

