### PR TITLE
chore(backend): add drizzle-kit db:studio script in package.json

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -16,7 +16,8 @@
 		"lint:fix": "biome check --write .",
 		"db:generate": "drizzle-kit generate --config src/config/drizzle-kit.config.ts",
 		"db:migrate": "drizzle-kit migrate --config src/config/drizzle-kit.config.ts",
-		"db:push": "drizzle-kit push --config src/config/drizzle-kit.config.ts"
+		"db:push": "drizzle-kit push --config src/config/drizzle-kit.config.ts",
+		"db:studio": "drizzle-kit studio --config src/config/drizzle-kit.config.ts --host 0.0.0.0 --verbose"
 	},
 	"dependencies": {
 		"better-auth": "1.4.13",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a db:studio script to launch Drizzle Kit Studio with src/config/drizzle-kit.config.ts. Binds to 0.0.0.0 for container access and enables verbose logs.

<sup>Written for commit 378dc695941bb7d26b265f9285a520eb80cd64c6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

