### PR TITLE
chore(version): change vee-validate bump from major to patch

### DIFF
--- a/.changeset/brave-ducks-bow.md
+++ b/.changeset/brave-ducks-bow.md
@@ -1,6 +1,5 @@
 ---
-"web": major
+"web": patch
 ---
 
-- **WHAT changed**: Upgraded `@vee-validate/nuxt` from `4.15.1` to `5.0.0-beta.0` along with `vee-validate` core. This introduces breaking changes: forms built with v4 stopped validating correctly due to API differences.
-- **WHY the change was made**: Companion packages such as `@vee-validate/zod` were removed in v5. This simplifies the setup to just `@vee-validate/nuxt` and makes it possible to upgrade peer dependencies more easily.
+refactor: update vee-validate to 5.x and companion packages removed in v5.


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Changed the changeset for the vee-validate upgrade from major to patch for the web package. This avoids an unnecessary major release and only updates release metadata; no runtime changes.

<sup>Written for commit ff3216987a490960ec2b0756b58b2b6e9620f791. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

