### PR TITLE
refactor(web): migrate app.vue to use NuxtLayout component

### DIFF
--- a/.changeset/vast-streets-fry.md
+++ b/.changeset/vast-streets-fry.md
@@ -1,0 +1,5 @@
+---
+"web": patch
+---
+
+refactor: migrate app.vue to use NuxtLayout component

--- a/apps/frontend/src/app.vue
+++ b/apps/frontend/src/app.vue
@@ -1,11 +1,8 @@
 <template>
-	<div class="App">
-		<AppHeader />
-		<main class="App__main">
+	<div>
+		<NuxtLayout>
 			<NuxtPage />
-		</main>
-		<FeedbackWidget />
-		<AppFooter />
+		</NuxtLayout>
 	</div>
 </template>
 <script setup lang="ts">
@@ -13,16 +10,3 @@ useHead({
 	titleTemplate: '%s | Receitas de Crochê'
 })
 </script>
-
-<style scoped lang="scss">
-.App {
-	display: flex;
-	flex-direction: column;
-	min-height: 100vh;
-
-	&__main {
-		flex: 1;
-		padding: 2.8rem 0;
-	}
-}
-</style>

--- a/apps/frontend/src/layouts/default.vue
+++ b/apps/frontend/src/layouts/default.vue
@@ -1,0 +1,23 @@
+<template>
+	<div class="default">
+		<AppHeader />
+		<main class="default-content">
+			<slot />
+		</main>
+		<FeedbackWidget />
+		<AppFooter />
+	</div>
+</template>
+
+<style lang="scss">
+.default {
+	display: flex;
+	flex-direction: column;
+	min-height: 100vh;
+
+	&-content {
+		flex: 1;
+		padding: 2.8rem 0;
+	}
+}
+</style>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Migrated app.vue to use NuxtLayout and moved header/footer into a new default layout. This centralizes the page structure and makes it easier to add more layouts later.

- **Refactors**
  - Replaced inline layout in app.vue with NuxtLayout wrapping NuxtPage.
  - Added layouts/default.vue with AppHeader, FeedbackWidget, AppFooter, and slot for page content.
  - Moved layout styles from app.vue to the default layout.

<sup>Written for commit b9fdf2ce034f2a5fb3b6436ef286deb59c4fb73c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

