### PR TITLE
refactor(web): migrate to zod v4.x

### DIFF
--- a/.changeset/clean-seas-do.md
+++ b/.changeset/clean-seas-do.md
@@ -1,0 +1,5 @@
+---
+"web": patch
+---
+
+refactor: migrate to zod v4.x

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -26,7 +26,7 @@
 		"pinia": "3.0.4",
 		"vue": "3.5.26",
 		"vue-router": "4.5.1",
-		"zod": "3.25.76"
+		"zod": "4.3.5"
 	},
 	"devDependencies": {
 		"@nuxt/eslint": "1.12.1",

--- a/apps/frontend/src/validations/feedback.validation.ts
+++ b/apps/frontend/src/validations/feedback.validation.ts
@@ -2,6 +2,6 @@ import { z } from 'zod'
 
 export const feedbackZodSchema = z.object({
 	feedback: z
-		.string({ required_error: '*Preencha esse campo' })
+		.string({ error: '*Preencha esse campo' })
 		.nonempty({ message: '*Preencha esse campo' })
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -112,8 +112,8 @@ importers:
         specifier: 4.5.1
         version: 4.5.1(vue@3.5.26(typescript@5.9.3))
       zod:
-        specifier: 3.25.76
-        version: 3.25.76
+        specifier: 4.3.5
+        version: 4.3.5
     devDependencies:
       '@nuxt/eslint':
         specifier: 1.12.1
@@ -8524,9 +8524,6 @@ packages:
   zip-stream@6.0.1:
     resolution: {integrity: sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==}
     engines: {node: '>= 14'}
-
-  zod@3.25.76:
-    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
   zod@4.3.5:
     resolution: {integrity: sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==}
@@ -17880,7 +17877,5 @@ snapshots:
       archiver-utils: 5.0.2
       compress-commons: 6.0.2
       readable-stream: 4.7.0
-
-  zod@3.25.76: {}
 
   zod@4.3.5: {}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Migrated the frontend to Zod v4 to align with the new validation API and remove deprecated options. This keeps validation consistent and prevents warnings.

- **Dependencies**
  - Bumped zod to 4.3.5 and updated pnpm-lock.

- **Refactors**
  - Updated feedback schema to use string({ error }) instead of required_error.

<sup>Written for commit a87fa0e9c6fb4bb543df0f28bd9ada6e22edb6ec. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

