### PR TITLE
feat(backend): add better-auth-localization package and config

### DIFF
--- a/.changeset/late-icons-invite.md
+++ b/.changeset/late-icons-invite.md
@@ -1,0 +1,5 @@
+---
+"backend": minor
+---
+
+feat(backend): add better-auth-localization package and config

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,6 @@
 	"editor.formatOnSave": true,
 	"editor.codeActionsOnSave": {
 		"source.organizeImports.biome": "explicit"
-	}
+	},
+	"biome.lsp.bin": "./apps/backend/node_modules/@biomejs/biome/bin/biome"
 }

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -21,6 +21,7 @@
 	},
 	"dependencies": {
 		"better-auth": "1.4.13",
+		"better-auth-localization": "2.2.3",
 		"bullmq": "5.66.5",
 		"cors": "2.8.5",
 		"drizzle-orm": "0.45.1",

--- a/apps/backend/src/config/better-auth.config.ts
+++ b/apps/backend/src/config/better-auth.config.ts
@@ -1,9 +1,11 @@
+import { env } from "@config/env.config.ts";
 import db from "@db/index.ts";
 import { betterAuth } from "better-auth";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
 import { jwt, openAPI } from "better-auth/plugins";
 
 export const auth = betterAuth({
+	trustedOrigins: [env.FRONTEND_URL],
 	database: drizzleAdapter(db, {
 		provider: "pg",
 		usePlural: true,

--- a/apps/backend/src/config/better-auth.config.ts
+++ b/apps/backend/src/config/better-auth.config.ts
@@ -1,9 +1,9 @@
 import { env } from "@config/env.config.ts";
 import db from "@db/index.ts";
 import { betterAuth } from "better-auth";
-import { localization } from "better-auth-localization";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
 import { jwt, openAPI } from "better-auth/plugins";
+import { localization } from "better-auth-localization";
 
 export const auth = betterAuth({
 	trustedOrigins: [env.FRONTEND_URL],
@@ -24,7 +24,7 @@ export const auth = betterAuth({
 		localization({
 			defaultLocale: "pt-BR",
 			fallbackLocale: "default",
-		})
+		}),
 	],
 	emailAndPassword: {
 		enabled: true,

--- a/apps/backend/src/config/better-auth.config.ts
+++ b/apps/backend/src/config/better-auth.config.ts
@@ -1,6 +1,7 @@
 import { env } from "@config/env.config.ts";
 import db from "@db/index.ts";
 import { betterAuth } from "better-auth";
+import { localization } from "better-auth-localization";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
 import { jwt, openAPI } from "better-auth/plugins";
 
@@ -20,6 +21,10 @@ export const auth = betterAuth({
 			},
 		}),
 		openAPI(),
+		localization({
+			defaultLocale: "pt-BR",
+			fallbackLocale: "default",
+		})
 	],
 	emailAndPassword: {
 		enabled: true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       better-auth:
         specifier: 1.4.13
         version: 1.4.13(drizzle-kit@0.31.8)(drizzle-orm@0.45.1(@types/pg@8.16.0)(kysely@0.28.10)(pg@8.17.1))(pg@8.17.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vitest@4.0.17(@types/node@25.0.9)(happy-dom@17.6.3)(jiti@2.6.1)(lightningcss@1.31.0)(sass-embedded@1.97.2)(sass@1.97.2)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vue@3.5.26(typescript@5.9.3))
+      better-auth-localization:
+        specifier: 2.2.3
+        version: 2.2.3(better-auth@1.4.13(drizzle-kit@0.31.8)(drizzle-orm@0.45.1(@types/pg@8.16.0)(kysely@0.28.10)(pg@8.17.1))(pg@8.17.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vitest@4.0.17(@types/node@25.0.9)(happy-dom@17.6.3)(jiti@2.6.1)(lightningcss@1.31.0)(sass-embedded@1.97.2)(sass@1.97.2)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vue@3.5.26(typescript@5.9.3)))
       bullmq:
         specifier: 5.66.5
         version: 5.66.5
@@ -3658,6 +3661,11 @@ packages:
   baseline-browser-mapping@2.9.16:
     resolution: {integrity: sha512-KeUZdBuxngy825i8xvzaK1Ncnkx0tBmb3k8DkEuqjKRkmtvNTjey2ZsNeh8Dw4lfKvbCOu9oeNx2TKm2vHqcRw==}
     hasBin: true
+
+  better-auth-localization@2.2.3:
+    resolution: {integrity: sha512-FS39zJIbVIuNGQISrGJ6sVPaorGHCWfp77LqWmJk73/X9e39uCLk1p8bp4qfwQpiePw0NRFlTgi8U/yMPeekWQ==}
+    peerDependencies:
+      better-auth: ^1.3.27
 
   better-auth@1.4.13:
     resolution: {integrity: sha512-frGQmYT0rglidLpx91SP9n4ztaNBFGBb0JrWSdMTAHvhBkmQlUT/43e0IboMK2mPrAZFlvhdcMV8jCnqpYVE9A==}
@@ -12555,6 +12563,33 @@ snapshots:
   base64-js@1.5.1: {}
 
   baseline-browser-mapping@2.9.16: {}
+
+  better-auth-localization@2.2.3(better-auth@1.4.13(drizzle-kit@0.31.8)(drizzle-orm@0.45.1(@types/pg@8.16.0)(kysely@0.28.10)(pg@8.17.1))(pg@8.17.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vitest@4.0.17(@types/node@25.0.9)(happy-dom@17.6.3)(jiti@2.6.1)(lightningcss@1.31.0)(sass-embedded@1.97.2)(sass@1.97.2)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vue@3.5.26(typescript@5.9.3))):
+    dependencies:
+      better-auth: 1.4.13(drizzle-kit@0.31.8)(drizzle-orm@0.45.1(@types/pg@8.16.0)(kysely@0.28.10)(pg@8.17.1))(pg@8.17.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vitest@4.0.17(@types/node@25.0.9)(happy-dom@17.6.3)(jiti@2.6.1)(lightningcss@1.31.0)(sass-embedded@1.97.2)(sass@1.97.2)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vue@3.5.26(typescript@5.9.3))
+
+  better-auth@1.4.13(drizzle-kit@0.31.8)(drizzle-orm@0.45.1(@types/pg@8.16.0)(kysely@0.28.10)(pg@8.17.1))(pg@8.17.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vitest@3.2.4(@types/node@25.0.9)(happy-dom@17.6.3)(jiti@2.6.1)(lightningcss@1.31.0)(sass-embedded@1.97.2)(sass@1.97.2)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vue@3.5.26(typescript@5.9.3)):
+    dependencies:
+      '@better-auth/core': 1.4.13(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.7(zod@4.3.5))(jose@6.1.3)(kysely@0.28.10)(nanostores@1.1.0)
+      '@better-auth/telemetry': 1.4.13(@better-auth/core@1.4.13(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.7(zod@4.3.5))(jose@6.1.3)(kysely@0.28.10)(nanostores@1.1.0))
+      '@better-auth/utils': 0.3.0
+      '@better-fetch/fetch': 1.1.21
+      '@noble/ciphers': 2.1.1
+      '@noble/hashes': 2.0.1
+      better-call: 1.1.7(zod@4.3.5)
+      defu: 6.1.4
+      jose: 6.1.3
+      kysely: 0.28.10
+      nanostores: 1.1.0
+      zod: 4.3.5
+    optionalDependencies:
+      drizzle-kit: 0.31.8
+      drizzle-orm: 0.45.1(@types/pg@8.16.0)(kysely@0.28.10)(pg@8.17.1)
+      pg: 8.17.1
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+      vitest: 3.2.4(@types/node@25.0.9)(happy-dom@17.6.3)(jiti@2.6.1)(lightningcss@1.31.0)(sass-embedded@1.97.2)(sass@1.97.2)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vue: 3.5.26(typescript@5.9.3)
 
   better-auth@1.4.13(drizzle-kit@0.31.8)(drizzle-orm@0.45.1(@types/pg@8.16.0)(kysely@0.28.10)(pg@8.17.1))(pg@8.17.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vitest@4.0.17(@types/node@25.0.9)(happy-dom@17.6.3)(jiti@2.6.1)(lightningcss@1.31.0)(sass-embedded@1.97.2)(sass@1.97.2)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vue@3.5.26(typescript@5.9.3)):
     dependencies:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add Better Auth localization to the backend with pt-BR as the default. Also restrict auth requests using trustedOrigins from FRONTEND_URL.

- **New Features**
  - Enable localization plugin with defaultLocale "pt-BR" and fallback "default".
  - Configure trustedOrigins: [env.FRONTEND_URL].

- **Dependencies**
  - Add better-auth-localization@2.2.3 to backend.

<sup>Written for commit b7a4c6ebbe830e1402b6978e2619e136158ec72f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

