### PR TITLE
feat(web): add AuthRedirect server middleware

### DIFF
--- a/.changeset/true-pandas-check.md
+++ b/.changeset/true-pandas-check.md
@@ -1,0 +1,5 @@
+---
+"web": minor
+---
+
+feat(web): add AuthRedirect server middleware

--- a/apps/frontend/nuxt.config.ts
+++ b/apps/frontend/nuxt.config.ts
@@ -69,6 +69,7 @@ export default defineNuxtConfig({
 		'@composables': fileURLToPath(new URL('./src/composables', import.meta.url)),
 		'@validations': fileURLToPath(new URL('./src/validations', import.meta.url)),
 		'@interfaces': fileURLToPath(new URL('./src/interfaces', import.meta.url)),
-		'@services': fileURLToPath(new URL('./src/services', import.meta.url))
+		'@services': fileURLToPath(new URL('./src/services', import.meta.url)),
+		'@utils': fileURLToPath(new URL('./src/utils', import.meta.url))
 	}
 })

--- a/apps/frontend/src/server/middleware/auth-redirect.ts
+++ b/apps/frontend/src/server/middleware/auth-redirect.ts
@@ -1,0 +1,22 @@
+import type { SessionResponse } from '~/types/session-response'
+import authRoutes from '~/utils/auth-routes'
+
+export default defineEventHandler(async (event) => {
+	const urlsPath = event.node.req.url
+	const cookiesHeaders = event.node.req.headers.cookie
+	const config = useRuntimeConfig()
+
+	if (urlsPath && authRoutes.includes(urlsPath) && cookiesHeaders) {
+		try {
+			const session = await $fetch<SessionResponse>(config.public.apiUrl + '/auth/me', {
+				headers: Object.fromEntries([['cookie', cookiesHeaders]])
+			})
+
+			if (session && session.user) {
+				sendRedirect(event, '/')
+			}
+		} catch (error) {
+			console.error('Erro ao buscar sessão em /auth/me:', error)
+		}
+	}
+})

--- a/apps/frontend/src/types/session-response.ts
+++ b/apps/frontend/src/types/session-response.ts
@@ -1,0 +1,7 @@
+import type { sessionMiddleware } from 'better-auth/api'
+
+type RawSessionResponse = Awaited<ReturnType<typeof sessionMiddleware>>
+export type SessionResponse = {
+	session: RawSessionResponse['session']['session']
+	user: RawSessionResponse['session']['user']
+}

--- a/apps/frontend/src/utils/auth-routes.ts
+++ b/apps/frontend/src/utils/auth-routes.ts
@@ -1,0 +1,3 @@
+const authRoutes = ['/entrar', '/crie-sua-conta', '/esqueci-senha', '/redefinir-senha']
+
+export default authRoutes

--- a/apps/frontend/tsconfig.json
+++ b/apps/frontend/tsconfig.json
@@ -8,6 +8,7 @@
 			"@validations/*": ["validations/*"],
 			"@interfaces/*": ["interfaces/*"],
 			"@services/*": ["services/*"],
+			"@utils/*": ["utils/*"],
 			"@/*": ["*"]
 		},
 		"strict": true


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds server-side AuthRedirect middleware to send logged-in users away from auth pages to the home page. This prevents access to login, signup, and password flows when already authenticated.

- **New Features**
  - Middleware reads cookies and calls /auth/me to detect a session, then redirects to '/' if user exists.
  - Adds SessionResponse type for the auth/me response.
  - Introduces authRoutes utility and the @utils alias in Nuxt and tsconfig.

<sup>Written for commit c94938371d2e733bef957458cc9aedc292bc2bbb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

