### PR TITLE
feat(web): add SignIn page

### DIFF
--- a/.changeset/salty-planes-repair.md
+++ b/.changeset/salty-planes-repair.md
@@ -1,0 +1,5 @@
+---
+"web": minor
+---
+
+feat(web): add SignIn page

--- a/apps/frontend/src/components/UI/CheckboxField.vue
+++ b/apps/frontend/src/components/UI/CheckboxField.vue
@@ -1,0 +1,60 @@
+<template>
+	<div class="checkbox">
+		<input v-model="value" type="checkbox" v-bind="$attrs" class="field-input" />
+		<span class="checkmark">
+			<Icon name="material-symbols:check-rounded" size="16" />
+		</span>
+	</div>
+</template>
+
+<script setup>
+import { useField } from 'vee-validate'
+const inputProps = defineProps({
+	name: {
+		type: String,
+		required: true
+	}
+})
+const { value } = useField(inputProps.name, undefined, {
+	type: 'checkbox'
+})
+</script>
+
+<style scoped lang="scss">
+.checkbox {
+	position: relative;
+	height: 1.6rem;
+}
+
+.checkbox input[type='checkbox'] {
+	appearance: none;
+	-webkit-appearance: none;
+	width: 1.6rem;
+	height: 1.6rem;
+	border: 2px solid #ccc;
+	border-radius: 1.4rem;
+	cursor: pointer;
+	position: relative;
+}
+
+.checkbox .checkmark {
+	border-radius: 1.4rem;
+	position: absolute;
+	top: 0;
+	left: 0;
+	width: 1.6rem;
+	height: 1.6rem;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	color: transparent;
+	font-size: 1.6rem;
+	pointer-events: none;
+}
+
+.checkbox input[type='checkbox']:checked + .checkmark {
+	background-color: #c93f1d;
+	border-color: #c93f1d;
+	color: #fff;
+}
+</style>

--- a/apps/frontend/src/components/sign-in-form.vue
+++ b/apps/frontend/src/components/sign-in-form.vue
@@ -1,0 +1,227 @@
+<script setup lang="ts">
+import AppDivider from '@components/UI/AppDivider.vue'
+import CheckboxField from '@components/UI/CheckboxField.vue'
+import InputField from '@components/UI/InputField.vue'
+import LabelField from '@components/UI/LabelField.vue'
+import type { SignIn } from '@interfaces/sign-in.interface'
+import signIn from '@services/auth/sign-in.service'
+import { signInSchema } from '@validations/sign-in.validation'
+import { toast } from 'vue-sonner'
+
+const { errors, meta, isSubmitting, handleSubmit } = useForm<SignIn>({
+	validationSchema: signInSchema,
+	initialValues: {
+		rememberMe: true
+	}
+})
+
+const { value: rememberMe } = useField<boolean>('rememberMe')
+
+const showPassword = ref(false)
+const route = useRoute()
+const redirect_uri = route.query.redirect ? route.query.redirect.toString() : '/'
+
+const onSubmit = handleSubmit(async (data: SignIn) => {
+	try {
+		await signIn(data)
+
+		await new Promise((resolve) => setTimeout(resolve, 2000))
+		await navigateTo(redirect_uri)
+	} catch (error) {
+		console.error('Erro ao logar:', error)
+
+		const err = error as AuthClientError
+
+		if (err.code) {
+			toast.error(err.message || 'Erro ao entrar. Tente novamente mais tarde.')
+		} else {
+			toast.error('Erro inesperado. Tente novamente mais tarde.')
+		}
+	}
+})
+</script>
+<template>
+	<form class="signIn-form" @submit.prevent="onSubmit">
+		<div class="field-container">
+			<LabelField label="Email" for="email" />
+			<div class="field-input-container" :class="{ 'field-error': errors.email }">
+				<Icon name="material-symbols:mail-outline-rounded" size="16" style="color: #756157" />
+				<InputField
+					id="email"
+					name="email"
+					type="email"
+					placeholder="seu@email.com"
+					autocomplete="email"
+				/>
+			</div>
+			<span v-if="errors.email" class="error">{{ errors.email }}</span>
+		</div>
+		<div class="field-container">
+			<LabelField label="Senha" for="password" />
+			<div class="field-input-container" :class="{ 'field-error': errors.password }">
+				<Icon name="charm:padlock" size="16" style="color: #756157" />
+				<InputField
+					id="password"
+					name="password"
+					:type="showPassword ? 'text' : 'password'"
+					placeholder="••••••"
+					style="padding-top: 0.5rem"
+				/>
+				<Icon
+					:name="
+						showPassword
+							? 'material-symbols:visibility-off-outline-rounded'
+							: 'material-symbols:visibility-outline-rounded'
+					"
+					size="16"
+					style="color: #756157"
+					@click="showPassword = !showPassword"
+				/>
+			</div>
+			<span v-if="errors.password" class="error">{{ errors.password }}</span>
+		</div>
+		<div class="field-actions">
+			<div class="remember-me" @click="rememberMe = !rememberMe">
+				<CheckboxField id="rememberMe" name="rememberMe" :checked="rememberMe" />
+				<LabelField label="Manter conectado" for="rememberMe" />
+			</div>
+			<span v-if="errors.rememberMe" class="error">{{ errors.rememberMe }}</span>
+			<p class="forgot-password">
+				<AppLink to="/esqueci-senha" class="login-link">Esqueceu a senha?</AppLink>
+			</p>
+		</div>
+		<button class="btn btn--submit" type="submit" :disabled="!meta.valid">
+			<template v-if="!isSubmitting">Entrar</template>
+			<template v-else>
+				<AppLoading />
+			</template>
+		</button>
+		<p class="login-container">
+			Não tem uma conta?
+			<AppLink to="/crie-sua-conta" class="login-link">Cadastre-se</AppLink>
+		</p>
+		<AppDivider />
+		<p class="accept-terms">
+			Ao continuar, você concorda com nossa
+			<AppLink
+				to="/politica-de-privacidade"
+				class="accept-terms-link"
+				target="_blank"
+				rel="noopener noreferrer"
+			>
+				Política de Privacidade
+			</AppLink>
+		</p>
+	</form>
+</template>
+
+<style scoped lang="scss">
+.signIn {
+	&-form {
+		display: flex;
+		flex-direction: column;
+		gap: 1.6rem;
+	}
+}
+
+.field {
+	&-error,
+	&-error:focus {
+		border: 1px solid #d32f2f !important;
+	}
+
+	&-container {
+		display: flex;
+		flex-direction: column;
+		gap: 0.8rem;
+	}
+
+	&-actions {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+	}
+
+	&-input-container {
+		height: 4rem;
+		display: flex;
+		align-items: center;
+		gap: 0.8rem;
+		background-color: #ffffff;
+		border: #dfd1c380 1px solid;
+		border-radius: 1.2rem;
+		padding: 0 1.2rem;
+		color: #281c15;
+
+		&:focus-within {
+			border-color: #ff7f00;
+		}
+
+		.error {
+			display: none;
+		}
+	}
+}
+
+.btn {
+	padding: 1.6rem 0;
+}
+
+.error {
+	color: #ef4343;
+	font: 400 1.4rem / 1.6 $font-body;
+	margin-bottom: -0.8rem;
+}
+
+.login {
+	&-container {
+		font: 400 1.6rem / 1.2 $font-body;
+		color: #756157;
+		text-align: center;
+		margin: 1.2rem 0;
+	}
+
+	&-link {
+		color: #c93f1d;
+		font-weight: 600;
+
+		&:hover {
+			color: #c93f1dcc;
+		}
+	}
+}
+
+.remember-me {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	gap: 0.8rem;
+
+	.field-label {
+		line-height: 1.6rem;
+		cursor: pointer;
+		color: #756157;
+		font-weight: 400;
+	}
+}
+
+.forgot-password {
+	text-align: right;
+	font-size: 1.4rem;
+}
+
+.accept-terms {
+	font: 400 1.2rem / 1.2 $font-body;
+	color: #756157;
+	text-align: center;
+
+	&-link {
+		color: #c93f1d;
+
+		&:hover {
+			color: #c93f1dcc;
+			text-decoration: underline;
+		}
+	}
+}
+</style>

--- a/apps/frontend/src/interfaces/sign-in.interface.ts
+++ b/apps/frontend/src/interfaces/sign-in.interface.ts
@@ -1,0 +1,4 @@
+import type { signInSchema } from '@validations/sign-in.validation'
+import type { z } from 'zod'
+
+export type SignIn = z.infer<typeof signInSchema>

--- a/apps/frontend/src/pages/entrar.vue
+++ b/apps/frontend/src/pages/entrar.vue
@@ -1,0 +1,97 @@
+<script setup lang="ts">
+import SignInForm from '@components/sign-in-form.vue'
+
+useHead({
+	title: 'Entrar'
+})
+
+definePageMeta({
+	layout: false
+})
+</script>
+<template>
+	<div class="wrapper">
+		<AppContainer>
+			<div class="content">
+				<AppLink to="/" class="link-home">
+					<Icon name="material-symbols:arrow-back" size="16" />
+					Voltar para a loja
+				</AppLink>
+				<div class="signIn-container">
+					<div class="signIn-header">
+						<SvgIcon
+							name="short-logo"
+							label="Logo Receitas de Crochê"
+							role="img"
+							width="32"
+							height="36"
+							color="#683000"
+							class="signIn-logo"
+						/>
+						<h1 class="signIn-title">Bem-vindo(a) de volta!</h1>
+						<p class="signIn-description">Entre para acessar suas receitas favoritas</p>
+					</div>
+					<SignInForm />
+				</div>
+			</div>
+		</AppContainer>
+	</div>
+</template>
+<style lang="scss">
+.wrapper {
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	min-height: 100vh;
+	background: linear-gradient(to bottom right, #c93f1d, #c93f1de6, #f96706);
+}
+
+.content {
+	padding: 1.6rem 0;
+	margin: 0 auto;
+	width: 100%;
+	max-width: 44.8rem;
+	flex: 1;
+}
+
+.link-home {
+	display: flex;
+	align-items: center;
+	gap: 0.8rem;
+	margin-bottom: 2.4rem;
+	font: 400 1.6rem / 1.2 $font-body;
+	color: #eee3d3;
+	width: fit-content;
+}
+
+.signIn {
+	&-container {
+		background-color: #fffffff2;
+		border-radius: 1.4rem;
+		padding: 2.4rem;
+	}
+
+	&-header {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: 0.8rem;
+	}
+
+	&-logo {
+		margin-bottom: 0.8rem;
+	}
+
+	&-title {
+		font: 700 2.4rem / 1.2 $font-heading;
+		color: #281c15;
+	}
+
+	&-description {
+		font: 400 1.4rem / 1.2 $font-body;
+		text-align: center;
+		color: #756157;
+		margin-bottom: 1.6rem;
+	}
+}
+</style>

--- a/apps/frontend/src/services/auth/sign-in.service.ts
+++ b/apps/frontend/src/services/auth/sign-in.service.ts
@@ -1,0 +1,15 @@
+import type { SignIn } from '@interfaces/sign-in.interface'
+
+export default async function signIn({ email, password, rememberMe }: SignIn) {
+	const { $signIn } = useNuxtApp()
+
+	const { error } = await $signIn.email({
+		email,
+		password,
+		rememberMe
+	})
+
+	if (error) {
+		throw error
+	}
+}

--- a/apps/frontend/src/validations/base-auth.validation.ts
+++ b/apps/frontend/src/validations/base-auth.validation.ts
@@ -1,19 +1,9 @@
 import { confirmPasswordSchema, emailSchema, passwordSchema } from '@validations/fields'
 import z from 'zod'
 
-export const baseAuthSchema = z
-	.object({
-		fullName: z.string({ error: 'Nome é obrigatório' }).nonempty({ error: 'Nome é obrigatório' }),
-		email: emailSchema,
-		password: passwordSchema,
-		confirmPassword: confirmPasswordSchema
-	})
-	.superRefine(({ password, confirmPassword }, ctx) => {
-		if (password !== confirmPassword) {
-			ctx.addIssue({
-				code: 'custom',
-				message: 'Senhas precisam ser iguais',
-				path: ['confirmPassword']
-			})
-		}
-	})
+export const baseAuthSchema = z.object({
+	fullName: z.string({ error: 'Nome é obrigatório' }).nonempty({ error: 'Nome é obrigatório' }),
+	email: emailSchema,
+	password: passwordSchema,
+	confirmPassword: confirmPasswordSchema
+})

--- a/apps/frontend/src/validations/sign-in.validation.ts
+++ b/apps/frontend/src/validations/sign-in.validation.ts
@@ -1,0 +1,11 @@
+import { baseAuthSchema } from '@validations/base-auth.validation'
+import z from 'zod'
+
+export const signInSchema = baseAuthSchema
+	.pick({
+		email: true,
+		password: true
+	})
+	.extend({
+		rememberMe: z.boolean().default(true)
+	})

--- a/apps/frontend/src/validations/sign-up.validation.ts
+++ b/apps/frontend/src/validations/sign-up.validation.ts
@@ -1,3 +1,11 @@
 import { baseAuthSchema } from '@validations/base-auth.validation'
 
-export const signUpSchema = baseAuthSchema
+export const signUpSchema = baseAuthSchema.superRefine(({ password, confirmPassword }, ctx) => {
+	if (password !== confirmPassword) {
+		ctx.addIssue({
+			code: 'custom',
+			message: 'Senhas precisam ser iguais',
+			path: ['confirmPassword']
+		})
+	}
+})


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add Sign In page (/entrar) with email/password login, “remember me,” and redirect support. Integrates Zod + vee-validate and the auth service for a smoother login.

- **New Features**
  - Sign-in page with form, password visibility toggle, and links for reset and sign-up.
  - Validation via signInSchema; rememberMe defaults to true.
  - Auth integration using $signIn.email with toast errors and ?redirect handling.
  - New CheckboxField component integrated with vee-validate.

- **Refactors**
  - Moved password match check from base-auth to sign-up.validation.
  - baseAuthSchema now only defines fields; sign-in schema picks email/password and adds rememberMe.
  - Updated sign-up.validation to run the confirm password check.

<sup>Written for commit 3efcf2b802789bf21ecd8cde232e2872137b8c52. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

