### PR TITLE
feat(backend): add advanced cookie config and cross-subdomain support in better-auth.config.ts

### DIFF
--- a/.changeset/blue-points-joke.md
+++ b/.changeset/blue-points-joke.md
@@ -1,0 +1,5 @@
+---
+"backend": minor
+---
+
+feat: add advanced cookie config and cross-subdomain support in better-auth.config.ts

--- a/apps/backend/src/config/better-auth.config.ts
+++ b/apps/backend/src/config/better-auth.config.ts
@@ -7,6 +7,17 @@ import { localization } from "better-auth-localization";
 
 export const auth = betterAuth({
 	trustedOrigins: [env.FRONTEND_URL],
+	advanced: {
+		useSecureCookies: env.NODE_ENV === "production",
+		defaultCookieAttributes: {
+			secure: env.NODE_ENV === "production",
+			sameSite: env.NODE_ENV === "production" ? "None" : "Lax",
+		},
+		crossSubDomainCookies: {
+			enabled: env.NODE_ENV === "production",
+			domain: env.DOMAIN_ROOT,
+		},
+	},
 	database: drizzleAdapter(db, {
 		provider: "pg",
 		usePlural: true,

--- a/apps/backend/src/config/env.config.ts
+++ b/apps/backend/src/config/env.config.ts
@@ -1,5 +1,8 @@
 import { z } from "zod";
 
+const domainRoot = new URL(process.env.FRONTEND_URL ?? "http://localhost:3000")
+	.hostname;
+
 const envSchema = z.object({
 	PORT: z.coerce.number().default(3002),
 	SERVER_URL: z.string().url(),
@@ -17,6 +20,8 @@ const envSchema = z.object({
 	DB_URL: z.string().url(),
 	PGADMIN_USERNAME: z.string(),
 	PGADMIN_PASSWORD: z.string(),
+	NODE_ENV: z.string(),
+	DOMAIN_ROOT: z.string().default(domainRoot),
 });
 
 export const env = envSchema.parse(process.env);


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Enables advanced cookie settings for Better Auth to support secure, cross-subdomain sessions in production. Adds NODE_ENV-driven cookie attributes and a DOMAIN_ROOT-based cookie domain.

- **New Features**
  - Secure cookies and SameSite=None in production; Lax in dev.
  - Cross-subdomain cookies enabled in production using DOMAIN_ROOT.
  - Added DOMAIN_ROOT env (defaults to FRONTEND_URL hostname) and required NODE_ENV.

- **Migration**
  - Set NODE_ENV=production in production.
  - Optionally set DOMAIN_ROOT (e.g., .example.com) if it should differ from FRONTEND_URL’s hostname.

<sup>Written for commit 6d73f5fa3ea516ec2a26c2e1db8068f67a0c0654. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

