### PR TITLE
feat(backend): add sendResetPassword email in better-auth.config.ts

### DIFF
--- a/.changeset/free-forks-live.md
+++ b/.changeset/free-forks-live.md
@@ -1,0 +1,5 @@
+---
+"backend": minor
+---
+
+feat(better-auth): add sendResetPassword email

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -20,6 +20,7 @@
 		"db:studio": "drizzle-kit studio --config src/config/drizzle-kit.config.ts --host 0.0.0.0 --verbose"
 	},
 	"dependencies": {
+		"@react-email/render": "2.0.4",
 		"better-auth": "1.4.13",
 		"better-auth-localization": "2.2.3",
 		"bullmq": "5.66.5",
@@ -31,7 +32,8 @@
 		"pg": "8.17.1",
 		"resend": "6.5.2",
 		"tsup": "8.5.1",
-		"zod": "4.3.5"
+		"zod": "4.3.5",
+		"@rdc/transactional": "workspace:*"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "2.3.11",

--- a/apps/backend/src/config/better-auth.config.ts
+++ b/apps/backend/src/config/better-auth.config.ts
@@ -1,5 +1,8 @@
 import { env } from "@config/env.config.ts";
 import db from "@db/index.ts";
+import { PasswordResetEmail } from "@rdc/transactional";
+import { render } from "@react-email/render";
+import sendEmail from "@services/mail.service.ts";
 import { betterAuth } from "better-auth";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
 import { jwt, openAPI } from "better-auth/plugins";
@@ -39,5 +42,16 @@ export const auth = betterAuth({
 	],
 	emailAndPassword: {
 		enabled: true,
+		sendResetPassword: async ({ user, url }) => {
+			const resetPasswordTemplate = await render(
+				PasswordResetEmail({ resetLink: url, userEmail: user.email }),
+			);
+
+			void sendEmail({
+				to: user.email,
+				subject: "Redefinição de Senha - Receitas de Crochê",
+				body: resetPasswordTemplate,
+			});
+		},
 	},
 });

--- a/apps/backend/tsconfig.json
+++ b/apps/backend/tsconfig.json
@@ -24,8 +24,10 @@
 			"@services/*": ["services/*"],
 			"@validations/*": ["validations/*"],
 			"@db/*": ["db/*"],
+			"@rdc/transactional": ["../../packages/transactional/index.ts"],
 			"@/*": ["*"]
-		}
+		},
+		"jsx": "react-jsx"
 	},
 	"include": ["./src/**/*.ts", "**/*.test.ts", "**/*.spec.ts"],
 	"exclude": ["node_modules"]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,12 @@ importers:
 
   apps/backend:
     dependencies:
+      '@rdc/transactional':
+        specifier: workspace:*
+        version: link:../../packages/transactional
+      '@react-email/render':
+        specifier: 2.0.4
+        version: 2.0.4(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       better-auth:
         specifier: 1.4.13
         version: 1.4.13(drizzle-kit@0.31.8)(drizzle-orm@0.45.1(@types/pg@8.16.0)(kysely@0.28.10)(pg@8.17.1))(next@16.0.11(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.97.2))(pg@8.17.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vitest@4.0.17(@types/node@25.2.1)(happy-dom@17.6.3)(jiti@2.6.1)(lightningcss@1.31.0)(sass-embedded@1.97.2)(sass@1.97.2)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vue@3.5.26(typescript@5.9.3))


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a password reset email to the Better Auth flow. When a user requests a reset, we render the PasswordResetEmail template and send it via our mail service.

- **New Features**
  - Implemented emailAndPassword.sendResetPassword in better-auth.config.ts to send a reset link email.
  - Uses PasswordResetEmail from @rdc/transactional rendered with @react-email/render.

- **Dependencies**
  - Added @react-email/render and workspace @rdc/transactional.
  - Updated tsconfig: added @rdc/transactional path alias and enabled jsx: react-jsx.

<sup>Written for commit 3961a62bd7c75f55403ade9032eb1bdd7c77f5df. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

