### PR TITLE
feat(web): add ForgotPassword page

### DIFF
--- a/.changeset/late-bushes-fry.md
+++ b/.changeset/late-bushes-fry.md
@@ -1,0 +1,5 @@
+---
+"web": minor
+---
+
+feat: add ForgotPassword page

--- a/apps/frontend/src/components/forgot-password-form.vue
+++ b/apps/frontend/src/components/forgot-password-form.vue
@@ -1,39 +1,28 @@
 <script setup lang="ts">
 import AppDivider from '@components/UI/AppDivider.vue'
-import CheckboxField from '@components/UI/CheckboxField.vue'
 import InputField from '@components/UI/InputField.vue'
 import LabelField from '@components/UI/LabelField.vue'
-import type { SignIn } from '@interfaces/sign-in.interface'
-import signIn from '@services/auth/sign-in.service'
-import { signInSchema } from '@validations/sign-in.validation'
+import type { ForgotPassword } from '@interfaces/forgot-password.interface'
+import forgotPassword from '@services/auth/forgot-password.service'
+import { forgotPasswordSchema } from '@validations/forgot-password.validation'
 import { toast } from 'vue-sonner'
 
-const { errors, meta, isSubmitting, handleSubmit } = useForm<SignIn>({
-	validationSchema: signInSchema,
-	initialValues: {
-		rememberMe: true
-	}
+const { errors, meta, isSubmitting, handleSubmit, resetForm } = useForm<ForgotPassword>({
+	validationSchema: forgotPasswordSchema
 })
 
-const { value: rememberMe } = useField<boolean>('rememberMe')
-
-const showPassword = ref(false)
-const route = useRoute()
-const redirect_uri = route.query.redirect ? route.query.redirect.toString() : '/'
-
-const onSubmit = handleSubmit(async (data: SignIn) => {
+const onSubmit = handleSubmit(async (data: ForgotPassword) => {
 	try {
-		await signIn(data)
-
-		await new Promise((resolve) => setTimeout(resolve, 2000))
-		await navigateTo(redirect_uri)
+		await forgotPassword(data)
+		toast.success('Link de redefinição enviado, caso o e-mail esteja cadastrado.')
+		resetForm()
 	} catch (error) {
-		console.error('Erro ao logar:', error)
+		console.error('Erro forgotPassword page:', error)
 
 		const err = error as AuthClientError
 
 		if (err.code) {
-			toast.error(err.message || 'Erro ao entrar. Tente novamente mais tarde.')
+			toast.error(err.message || 'Erro ao redefinir senha. Tente novamente mais tarde.')
 		} else {
 			toast.error('Erro inesperado. Tente novamente mais tarde.')
 		}
@@ -41,7 +30,7 @@ const onSubmit = handleSubmit(async (data: SignIn) => {
 })
 </script>
 <template>
-	<form class="signIn-form" @submit.prevent="onSubmit">
+	<form class="forgotPassword-form" @submit.prevent="onSubmit">
 		<div class="field-container">
 			<LabelField label="Email" for="email" />
 			<div class="field-input-container" :class="{ 'field-error': errors.email }">
@@ -56,49 +45,14 @@ const onSubmit = handleSubmit(async (data: SignIn) => {
 			</div>
 			<span v-if="errors.email" class="error">{{ errors.email }}</span>
 		</div>
-		<div class="field-container">
-			<LabelField label="Senha" for="password" />
-			<div class="field-input-container" :class="{ 'field-error': errors.password }">
-				<Icon name="charm:padlock" size="16" style="color: #756157" />
-				<InputField
-					id="password"
-					name="password"
-					:type="showPassword ? 'text' : 'password'"
-					placeholder="••••••"
-					style="padding-top: 0.5rem"
-				/>
-				<Icon
-					:name="
-						showPassword
-							? 'material-symbols:visibility-off-outline-rounded'
-							: 'material-symbols:visibility-outline-rounded'
-					"
-					size="16"
-					style="color: #756157"
-					@click="showPassword = !showPassword"
-				/>
-			</div>
-			<span v-if="errors.password" class="error">{{ errors.password }}</span>
-		</div>
-		<div class="field-actions">
-			<div class="remember-me" @click="rememberMe = !rememberMe">
-				<CheckboxField id="rememberMe" name="rememberMe" :checked="rememberMe" />
-				<LabelField label="Manter conectado" for="rememberMe" />
-			</div>
-			<span v-if="errors.rememberMe" class="error">{{ errors.rememberMe }}</span>
-			<p class="forgot-password">
-				<AppLink to="/esqueci-a-senha" class="login-link">Esqueceu a senha?</AppLink>
-			</p>
-		</div>
 		<button class="btn btn--submit" type="submit" :disabled="!meta.valid">
-			<template v-if="!isSubmitting">Entrar</template>
+			<template v-if="!isSubmitting">Enviar link de redefinição</template>
 			<template v-else>
 				<AppLoading />
 			</template>
 		</button>
 		<p class="login-container">
-			Não tem uma conta?
-			<AppLink to="/crie-sua-conta" class="login-link">Cadastre-se</AppLink>
+			<AppLink to="/entrar" class="login-link">Voltar para o login</AppLink>
 		</p>
 		<AppDivider />
 		<p class="accept-terms">
@@ -116,7 +70,7 @@ const onSubmit = handleSubmit(async (data: SignIn) => {
 </template>
 
 <style scoped lang="scss">
-.signIn {
+.forgotPassword {
 	&-form {
 		display: flex;
 		flex-direction: column;
@@ -188,20 +142,6 @@ const onSubmit = handleSubmit(async (data: SignIn) => {
 		&:hover {
 			color: #c93f1dcc;
 		}
-	}
-}
-
-.remember-me {
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	gap: 0.8rem;
-
-	.field-label {
-		line-height: 1.6rem;
-		cursor: pointer;
-		color: #756157;
-		font-weight: 400;
 	}
 }
 

--- a/apps/frontend/src/interfaces/forgot-password.interface.ts
+++ b/apps/frontend/src/interfaces/forgot-password.interface.ts
@@ -1,0 +1,4 @@
+import type { forgotPasswordSchema } from '@validations/forgot-password.validation'
+import type { z } from 'zod'
+
+export type ForgotPassword = z.infer<typeof forgotPasswordSchema>

--- a/apps/frontend/src/pages/esqueci-a-senha.vue
+++ b/apps/frontend/src/pages/esqueci-a-senha.vue
@@ -1,0 +1,97 @@
+<script setup lang="ts">
+useHead({
+	title: 'Esqueci a Senha'
+})
+
+definePageMeta({
+	layout: false
+})
+</script>
+<template>
+	<div class="wrapper">
+		<AppContainer>
+			<div class="content">
+				<AppLink to="/" class="link-home">
+					<Icon name="material-symbols:arrow-back" size="16" />
+					Voltar para a loja
+				</AppLink>
+				<div class="forgotPassword-container">
+					<div class="forgotPassword-header">
+						<SvgIcon
+							name="short-logo"
+							label="Logo Receitas de Crochê"
+							role="img"
+							width="32"
+							height="36"
+							color="#683000"
+							class="forgotPassword-logo"
+						/>
+						<h1 class="forgotPassword-title">Redefinir senha</h1>
+						<p class="forgotPassword-description">
+							Digite seu e-mail para receber o link de redefinição
+						</p>
+					</div>
+					<ForgotPasswordForm />
+				</div>
+			</div>
+		</AppContainer>
+	</div>
+</template>
+<style lang="scss">
+.wrapper {
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	min-height: 100vh;
+	background: linear-gradient(to bottom right, #c93f1d, #c93f1de6, #f96706);
+}
+
+.content {
+	padding: 1.6rem 0;
+	margin: 0 auto;
+	width: 100%;
+	max-width: 44.8rem;
+	flex: 1;
+}
+
+.link-home {
+	display: flex;
+	align-items: center;
+	gap: 0.8rem;
+	margin-bottom: 2.4rem;
+	font: 400 1.6rem / 1.2 $font-body;
+	color: #eee3d3;
+	width: fit-content;
+}
+
+.forgotPassword {
+	&-container {
+		background-color: #fffffff2;
+		border-radius: 1.4rem;
+		padding: 2.4rem;
+	}
+
+	&-header {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: 0.8rem;
+	}
+
+	&-logo {
+		margin-bottom: 0.8rem;
+	}
+
+	&-title {
+		font: 700 2.4rem / 1.2 $font-heading;
+		color: #281c15;
+	}
+
+	&-description {
+		font: 400 1.4rem / 1.2 $font-body;
+		text-align: center;
+		color: #756157;
+		margin-bottom: 1.6rem;
+	}
+}
+</style>

--- a/apps/frontend/src/plugins/auth-client.plugin.ts
+++ b/apps/frontend/src/plugins/auth-client.plugin.ts
@@ -13,7 +13,8 @@ export default defineNuxtPlugin(() => {
 			authClient,
 			signUp: authClient.signUp,
 			signIn: authClient.signIn,
-			signOut: authClient.signOut
+			signOut: authClient.signOut,
+			forgotPassword: authClient.requestPasswordReset
 		}
 	}
 })

--- a/apps/frontend/src/services/auth/forgot-password.service.ts
+++ b/apps/frontend/src/services/auth/forgot-password.service.ts
@@ -1,0 +1,15 @@
+import type { ForgotPassword } from '@interfaces/forgot-password.interface'
+
+export default async function forgotPassword({ email }: ForgotPassword) {
+	const { $forgotPassword } = useNuxtApp()
+	const baseUrl = window.location.origin
+
+	const { error } = await $forgotPassword({
+		email,
+		redirectTo: `${baseUrl}/redefinir-senha`
+	})
+
+	if (error) {
+		throw error
+	}
+}

--- a/apps/frontend/src/types/auth.d.ts
+++ b/apps/frontend/src/types/auth.d.ts
@@ -6,6 +6,7 @@ declare module 'nuxt/app' {
 		$signUp: ReturnType<typeof createAuthClient>['signUp']
 		$signIn: ReturnType<typeof createAuthClient>['signIn']
 		$signOut: ReturnType<typeof createAuthClient>['signOut']
+		$forgotPassword: ReturnType<typeof createAuthClient>['requestPasswordReset']
 	}
 }
 
@@ -15,5 +16,6 @@ declare module 'vue' {
 		$signUp: ReturnType<typeof createAuthClient>['signUp']
 		$signIn: ReturnType<typeof createAuthClient>['signIn']
 		$signOut: ReturnType<typeof createAuthClient>['signOut']
+		$forgotPassword: ReturnType<typeof createAuthClient>['requestPasswordReset']
 	}
 }

--- a/apps/frontend/src/validations/forgot-password.validation.ts
+++ b/apps/frontend/src/validations/forgot-password.validation.ts
@@ -1,0 +1,5 @@
+import { baseAuthSchema } from '@validations/base-auth.validation'
+
+export const forgotPasswordSchema = baseAuthSchema.pick({
+	email: true
+})


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a Forgot Password flow so users can request a reset link from the sign-in screen. Updates the auth plugin to expose requestPasswordReset and wires a new page at /esqueci-a-senha.

- **New Features**
  - New page /esqueci-a-senha with ForgotPasswordForm and email validation (Zod).
  - Service calls $forgotPassword with redirectTo `${origin}/redefinir-senha`.
  - Auth plugin exposes forgotPassword (requestPasswordReset); types extended.
  - Sign-in link updated to point to the new route.
  - UX: success toast on request, error toasts on failure, disabled submit until valid, loading state.

<sup>Written for commit 64e409e70bed08d0e720ffcc305d0b0a47cbfd44. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

