### PR TITLE
chore(docker): add react-email dependency to backend service

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -12,6 +12,7 @@ services:
     depends_on:
       - redis
       - db
+      - react-email
     build: .
     container_name: crochet-patterns-backend
     working_dir: /home/node/app/apps/backend


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added react-email as a dependency of the backend service in docker-compose so it starts first. This ensures proper start order and avoids failures when the backend needs the email service.

<sup>Written for commit 3db3a898ca5a1b466085de41dc7e9c4fe4969f6b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

