### PR TITLE
refactor(InputField): remove error span

### DIFF
--- a/.changeset/cold-webs-swim.md
+++ b/.changeset/cold-webs-swim.md
@@ -2,4 +2,4 @@
 "web": patch
 ---
 
-refactor(InputField): remove error span"
+refactor(InputField): remove error span

--- a/.changeset/cold-webs-swim.md
+++ b/.changeset/cold-webs-swim.md
@@ -1,0 +1,5 @@
+---
+"web": patch
+---
+
+refactor(InputField): remove error span"

--- a/apps/frontend/src/components/UI/InputField.vue
+++ b/apps/frontend/src/components/UI/InputField.vue
@@ -1,6 +1,5 @@
 <template>
 	<input v-model="value" v-bind="$attrs" class="field-input" />
-	<span class="error">{{ errorMessage }}</span>
 </template>
 
 <script setup>
@@ -11,7 +10,7 @@ const inputProps = defineProps({
 		required: true
 	}
 })
-const { value, errorMessage } = useField(() => inputProps.name)
+const { value } = useField(() => inputProps.name)
 </script>
 
 <style scoped lang="scss">
@@ -30,9 +29,5 @@ const { value, errorMessage } = useField(() => inputProps.name)
 		-webkit-text-fill-color: #281c15 !important;
 		transition: background-color 5000s ease-in-out 0s;
 	}
-}
-.error {
-	color: #ef4343;
-	font: 400 1.4rem / 1.6 $font-body;
 }
 </style>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed the inline error span from InputField and stopped using errorMessage to simplify the component and avoid duplicate validation UI. Also removed the associated .error styles.

<sup>Written for commit 34be3f4da3eedf16519737407f9b9a1cc861a132. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

