### PR TITLE
refactor(backend): update password min length to 6

### DIFF
--- a/.changeset/green-terms-grin.md
+++ b/.changeset/green-terms-grin.md
@@ -1,0 +1,5 @@
+---
+"backend": patch
+---
+
+refactor: update password min length to 6

--- a/apps/backend/src/config/better-auth.config.ts
+++ b/apps/backend/src/config/better-auth.config.ts
@@ -42,6 +42,7 @@ export const auth = betterAuth({
 	],
 	emailAndPassword: {
 		enabled: true,
+		minPasswordLength: 6,
 		sendResetPassword: async ({ user, url }) => {
 			const resetPasswordTemplate = await render(
 				PasswordResetEmail({ resetLink: url, userEmail: user.email }),


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Set minPasswordLength to 6 for email/password authentication in the backend BetterAuth config. This updates validation for signup and password reset flows to use the new rule.

<sup>Written for commit 60367d9d7b4025fb8cea898799b69a92e10cf519. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

