### PR TITLE
feat(web) : add reset password page

### DIFF
--- a/.changeset/witty-bikes-unite.md
+++ b/.changeset/witty-bikes-unite.md
@@ -1,0 +1,5 @@
+---
+"web": minor
+---
+
+feat: add ResetPassword page

--- a/apps/frontend/src/components/reset-password-form.vue
+++ b/apps/frontend/src/components/reset-password-form.vue
@@ -1,0 +1,191 @@
+<script setup lang="ts">
+import AppDivider from '@components/UI/AppDivider.vue'
+import InputField from '@components/UI/InputField.vue'
+import LabelField from '@components/UI/LabelField.vue'
+import type { ResetPassword } from '@interfaces/reset-password.interface'
+import resetPassword from '@services/auth/reset-password.service'
+import { resetPasswordSchema } from '@validations/reset-password.validation'
+import { toast } from 'vue-sonner'
+
+const { errors, meta, isSubmitting, handleSubmit, resetForm } = useForm<ResetPassword>({
+	validationSchema: resetPasswordSchema
+})
+const showPassword = ref(false)
+const showConfirmPassword = ref(false)
+
+const onSubmit = handleSubmit(async (data: ResetPassword) => {
+	try {
+		await resetPassword(data)
+		toast.success('Nova senha criada com sucesso!')
+		resetForm()
+	} catch (error) {
+		console.error('Erro resetPassword page:', error)
+
+		const err = error as AuthClientError
+
+		if (err.code) {
+			toast.error(err.message || 'Erro ao criar nova senha. Tente novamente mais tarde.')
+		} else {
+			toast.error('Erro inesperado. Tente novamente mais tarde.')
+		}
+	}
+})
+</script>
+<template>
+	<form class="resetPassword-form" @submit.prevent="onSubmit">
+		<div class="field-container">
+			<LabelField label="Nova senha" for="password" />
+			<div class="field-input-container" :class="{ 'field-error': errors.password }">
+				<Icon name="charm:padlock" size="16" style="color: #756157" />
+				<InputField
+					id="password"
+					name="password"
+					:type="showPassword ? 'text' : 'password'"
+					placeholder="••••••"
+					style="padding-top: 0.5rem"
+				/>
+				<Icon
+					:name="
+						showPassword
+							? 'material-symbols:visibility-off-outline-rounded'
+							: 'material-symbols:visibility-outline-rounded'
+					"
+					size="16"
+					style="color: #756157"
+					@click="showPassword = !showPassword"
+				/>
+			</div>
+			<span class="error">{{ errors.password }}</span>
+		</div>
+		<div class="field-container">
+			<LabelField label="Confirmar nova senha" for="confirmPassword" />
+			<div class="field-input-container" :class="{ 'field-error': errors.confirmPassword }">
+				<Icon name="charm:padlock" size="16" style="color: #756157" />
+				<InputField
+					id="confirmPassword"
+					name="confirmPassword"
+					:type="showConfirmPassword ? 'text' : 'password'"
+					placeholder="••••••"
+					style="padding-top: 0.5rem"
+				/>
+				<Icon
+					:name="
+						showConfirmPassword
+							? 'material-symbols:visibility-off-outline-rounded'
+							: 'material-symbols:visibility-outline-rounded'
+					"
+					size="16"
+					style="color: #756157"
+					@click="showConfirmPassword = !showConfirmPassword"
+				/>
+			</div>
+			<span class="error">{{ errors.confirmPassword }}</span>
+		</div>
+		<div class="password-tip">
+			<p>
+				<strong>Dica:</strong>
+				Use uma senha com pelo menos 6 caracteres, combinando letras, números e símbolos para maior
+				segurança.
+			</p>
+		</div>
+		<button class="btn btn--submit" type="submit" :disabled="!meta.valid">
+			<template v-if="!isSubmitting">Redefinir senha</template>
+			<template v-else>
+				<AppLoading />
+			</template>
+		</button>
+		<AppDivider />
+		<p class="accept-terms">
+			Ao continuar, você concorda com nossa
+			<AppLink
+				to="/politica-de-privacidade"
+				class="accept-terms-link"
+				target="_blank"
+				rel="noopener noreferrer"
+			>
+				Política de Privacidade
+			</AppLink>
+		</p>
+	</form>
+</template>
+
+<style scoped lang="scss">
+.resetPassword {
+	&-form {
+		display: flex;
+		flex-direction: column;
+		gap: 1.6rem;
+	}
+}
+
+.field {
+	&-error,
+	&-error:focus {
+		border: 1px solid #d32f2f !important;
+	}
+
+	&-container {
+		display: flex;
+		flex-direction: column;
+		gap: 0.8rem;
+	}
+
+	&-actions {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+	}
+
+	&-input-container {
+		height: 4rem;
+		display: flex;
+		align-items: center;
+		gap: 0.8rem;
+		background-color: #ffffff;
+		border: #dfd1c380 1px solid;
+		border-radius: 1.2rem;
+		padding: 0 1.2rem;
+		color: #281c15;
+
+		&:focus-within {
+			border-color: #ff7f00;
+		}
+	}
+}
+
+.password-tip {
+	background-color: #efebe780;
+	padding: 1.2rem;
+	border-radius: 1.4rem;
+
+	p {
+		font: 400 1.2rem / 1.6 $font-body;
+		color: #756157;
+	}
+}
+
+.btn {
+	padding: 1.6rem 0;
+}
+
+.error {
+	color: #ef4343;
+	font: 400 1.4rem / 1.6 $font-body;
+	margin-bottom: -0.8rem;
+}
+
+.accept-terms {
+	font: 400 1.2rem / 1.2 $font-body;
+	color: #756157;
+	text-align: center;
+
+	&-link {
+		color: #c93f1d;
+
+		&:hover {
+			color: #c93f1dcc;
+			text-decoration: underline;
+		}
+	}
+}
+</style>

--- a/apps/frontend/src/interfaces/reset-password.interface.ts
+++ b/apps/frontend/src/interfaces/reset-password.interface.ts
@@ -1,0 +1,4 @@
+import type { resetPasswordSchema } from '@validations/reset-password.validation'
+import type { z } from 'zod'
+
+export type ResetPassword = z.infer<typeof resetPasswordSchema>

--- a/apps/frontend/src/pages/redefinir-senha.vue
+++ b/apps/frontend/src/pages/redefinir-senha.vue
@@ -1,0 +1,95 @@
+<script setup lang="ts">
+useHead({
+	title: 'Redefinir Senha'
+})
+
+definePageMeta({
+	layout: false
+})
+</script>
+<template>
+	<div class="wrapper">
+		<AppContainer>
+			<div class="content">
+				<AppLink to="/entrar" class="link-home">
+					<Icon name="material-symbols:arrow-back" size="16" />
+					Voltar para o login
+				</AppLink>
+				<div class="resetPassword-container">
+					<div class="resetPassword-header">
+						<SvgIcon
+							name="short-logo"
+							label="Logo Receitas de Crochê"
+							role="img"
+							width="32"
+							height="36"
+							color="#683000"
+							class="resetPassword-logo"
+						/>
+						<h1 class="resetPassword-title">Criar nova senha</h1>
+						<p class="resetPassword-description">Digite sua nova senha abaixo</p>
+					</div>
+					<ResetPasswordForm />
+				</div>
+			</div>
+		</AppContainer>
+	</div>
+</template>
+<style lang="scss">
+.wrapper {
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	min-height: 100vh;
+	background: linear-gradient(to bottom right, #c93f1d, #c93f1de6, #f96706);
+}
+
+.content {
+	padding: 1.6rem 0;
+	margin: 0 auto;
+	width: 100%;
+	max-width: 44.8rem;
+	flex: 1;
+}
+
+.link-home {
+	display: flex;
+	align-items: center;
+	gap: 0.8rem;
+	margin-bottom: 2.4rem;
+	font: 400 1.6rem / 1.2 $font-body;
+	color: #eee3d3;
+	width: fit-content;
+}
+
+.resetPassword {
+	&-container {
+		background-color: #fffffff2;
+		border-radius: 1.4rem;
+		padding: 2.4rem;
+	}
+
+	&-header {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: 0.8rem;
+	}
+
+	&-logo {
+		margin-bottom: 0.8rem;
+	}
+
+	&-title {
+		font: 700 2.4rem / 1.2 $font-heading;
+		color: #281c15;
+	}
+
+	&-description {
+		font: 400 1.4rem / 1.2 $font-body;
+		text-align: center;
+		color: #756157;
+		margin-bottom: 1.6rem;
+	}
+}
+</style>

--- a/apps/frontend/src/plugins/auth-client.plugin.ts
+++ b/apps/frontend/src/plugins/auth-client.plugin.ts
@@ -14,7 +14,8 @@ export default defineNuxtPlugin(() => {
 			signUp: authClient.signUp,
 			signIn: authClient.signIn,
 			signOut: authClient.signOut,
-			forgotPassword: authClient.requestPasswordReset
+			forgotPassword: authClient.requestPasswordReset,
+			resetPassword: authClient.resetPassword
 		}
 	}
 })

--- a/apps/frontend/src/services/auth/reset-password.service.ts
+++ b/apps/frontend/src/services/auth/reset-password.service.ts
@@ -1,0 +1,16 @@
+import type { ResetPassword } from '@interfaces/reset-password.interface'
+
+export default async function resetPassword({ password }: ResetPassword) {
+	const { $resetPassword } = useNuxtApp()
+	const route = useRoute()
+	const token = route.query.token ? route.query.token.toString() : ''
+
+	const { error } = await $resetPassword({
+		newPassword: password,
+		token
+	})
+
+	if (error) {
+		throw error
+	}
+}

--- a/apps/frontend/src/types/auth.d.ts
+++ b/apps/frontend/src/types/auth.d.ts
@@ -7,6 +7,7 @@ declare module 'nuxt/app' {
 		$signIn: ReturnType<typeof createAuthClient>['signIn']
 		$signOut: ReturnType<typeof createAuthClient>['signOut']
 		$forgotPassword: ReturnType<typeof createAuthClient>['requestPasswordReset']
+		$resetPassword: ReturnType<typeof createAuthClient>['resetPassword']
 	}
 }
 
@@ -17,5 +18,6 @@ declare module 'vue' {
 		$signIn: ReturnType<typeof createAuthClient>['signIn']
 		$signOut: ReturnType<typeof createAuthClient>['signOut']
 		$forgotPassword: ReturnType<typeof createAuthClient>['requestPasswordReset']
+		$resetPassword: ReturnType<typeof createAuthClient>['resetPassword']
 	}
 }

--- a/apps/frontend/src/validations/reset-password.validation.ts
+++ b/apps/frontend/src/validations/reset-password.validation.ts
@@ -1,0 +1,16 @@
+import { baseAuthSchema } from '@validations/base-auth.validation'
+
+export const resetPasswordSchema = baseAuthSchema
+	.pick({
+		password: true,
+		confirmPassword: true
+	})
+	.superRefine(({ password, confirmPassword }, ctx) => {
+		if (password !== confirmPassword) {
+			ctx.addIssue({
+				code: 'custom',
+				message: 'Senhas precisam ser iguais',
+				path: ['confirmPassword']
+			})
+		}
+	})


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a Reset Password page so users can set a new password via a tokenized link. Includes a validated form and integrates with the auth client’s resetPassword API.

- **New Features**
  - New route: /redefinir-senha with ResetPasswordForm.
  - Validation with zod: password and confirm must match; submit disabled until valid; show/hide toggles.
  - Service reads ?token= from URL and calls $resetPassword({ newPassword, token }); success/error toasts.
  - Nuxt auth plugin now exposes $resetPassword; types updated.

- **Migration**
  - Ensure password reset emails link to /redefinir-senha?token=<token>.

<sup>Written for commit 9276920b256019f9a71eae40cb593d992beb29c1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

