### PR TITLE
refactor(middlewares): standardize validation error response format

### DIFF
--- a/.changeset/floppy-islands-joke.md
+++ b/.changeset/floppy-islands-joke.md
@@ -1,0 +1,5 @@
+---
+"backend": patch
+---
+
+refactor(middlewares): standardize validation error response format

--- a/apps/backend/src/middlewares/validateBody.middleware.ts
+++ b/apps/backend/src/middlewares/validateBody.middleware.ts
@@ -4,16 +4,19 @@ import type { ZodObject } from "zod";
 const validateBody =
 	(schema: ZodObject) => (req: Request, res: Response, next: NextFunction) => {
 		const result = schema.safeParse(req.body);
+
 		if (result.success) {
 			next();
 		} else {
-			const errorMessages = result.error.issues.map((issue) => ({
-				field: issue.path.join(".") || "body",
+			const errorsMessages = result.error.issues.map((issue) => ({
+				path: issue.path.join("."),
 				message: issue.message,
 				code: issue.code,
 			}));
 
-			res.status(400).json({ error: "Invalid data", details: errorMessages });
+			res
+				.status(400)
+				.json({ message: "Dados inválidos", errors: errorsMessages });
 		}
 	};
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Standardized the validation error response from validateBody middleware. It now returns 400 with { message: "Dados inválidos", errors: [{ path, message, code }] } for consistent client handling.

<sup>Written for commit 9db635c81158872f3121c2f71643081e22357c20. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

