### PR TITLE
feat(backend): integrate feedback email template and attachments support

### DIFF
--- a/.changeset/busy-facts-stand.md
+++ b/.changeset/busy-facts-stand.md
@@ -1,0 +1,5 @@
+---
+"backend": minor
+---
+
+integrate feedback email template and attachments support

--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -21,8 +21,8 @@ const app: Application = express();
 
 app.use(cors(corsOptions));
 app.use("/auth", authRouter);
-app.use(express.json());
-app.use(express.urlencoded({ extended: true }));
+app.use(express.json({ limit: "5mb" }));
+app.use(express.urlencoded({ limit: "5mb", extended: true }));
 app.use(express.static(path.join(__dirname, "../public")));
 app.use(routes);
 

--- a/apps/backend/src/controllers/feedback.controller.ts
+++ b/apps/backend/src/controllers/feedback.controller.ts
@@ -4,17 +4,16 @@ import type { Request, Response } from "express";
 
 export const sendFeedback = async (req: Request, res: Response) => {
 	try {
-		const { feedback }: FeedbackSchema = req.body;
+		const data: FeedbackSchema = req.body;
 
-		if (!feedback || feedback.trim() === "") {
-			return res.status(400).json({ message: "Feedback is required" });
-		}
+		await addFeedbackJob(data);
 
-		await addFeedbackJob(feedback);
-
-		return res.status(200).json({ message: "Feedback received", feedback });
+		return res
+			.status(200)
+			.json({ message: "Feedback received", feedback: data.feedback });
 	} catch (error) {
 		console.error("Error sending feedback:", error);
+
 		return res
 			.status(500)
 			.json({ message: "Internal server error sending feedback" });

--- a/apps/backend/src/services/mail.service.ts
+++ b/apps/backend/src/services/mail.service.ts
@@ -1,14 +1,21 @@
+import { env } from "@config/env.config.ts";
 import { Resend } from "resend";
 import type EmailPayload from "@/types/email.types.ts";
-export default async function sendEmail({ to, subject, body }: EmailPayload) {
+export default async function sendEmail({
+	to,
+	subject,
+	body,
+	attachments,
+}: EmailPayload) {
 	try {
-		const resend = new Resend(process.env.RESEND_API_KEY!);
+		const resend = new Resend(env.RESEND_API_KEY);
 
 		const response = await resend.emails.send({
-			from: process.env.MAIL_SENDER!,
+			from: env.MAIL_SENDER,
 			to,
 			subject,
 			html: body,
+			attachments,
 		});
 
 		if (response.error) {

--- a/apps/backend/src/types/email.types.ts
+++ b/apps/backend/src/types/email.types.ts
@@ -1,5 +1,8 @@
+import type { Attachment } from "resend";
+
 export default interface EmailPayload {
 	to: string;
 	subject: string;
 	body: string;
+	attachments?: Attachment[];
 }

--- a/apps/backend/src/validations/feedback.validation.ts
+++ b/apps/backend/src/validations/feedback.validation.ts
@@ -1,9 +1,17 @@
 import { z } from "zod";
 
+export const FeedbackTypeEnum = z.enum(["Problemas", "Ideias", "Outros"]);
+export type FeedbackType = z.infer<typeof FeedbackTypeEnum>;
+
 export const feedbackZodSchema = z.object({
-	feedback: z
-		.string({ error: "*Preencha esse campo" })
-		.nonempty({ error: "*Preencha esse campo" }),
+	feedback: z.string({ error: "*Preencha esse campo" }),
+	type: FeedbackTypeEnum,
+	screenshot: z
+		.string()
+		.optional()
+		.refine((value) => !value || value.startsWith("data:image/jpeg;base64,"), {
+			error: "Print deve ser uma imagem JPEG",
+		}),
 });
 
 export type FeedbackSchema = z.infer<typeof feedbackZodSchema>;

--- a/apps/backend/src/workers/email.worker.ts
+++ b/apps/backend/src/workers/email.worker.ts
@@ -7,12 +7,13 @@ new Worker(
 	"emailQueue",
 	async (job: Job<EmailPayload>) => {
 		try {
-			const { to, subject, body } = job.data;
+			const { to, subject, body, attachments } = job.data;
 
 			await sendEmail({
 				to,
 				subject,
 				body,
+				attachments,
 			});
 
 			console.log(`Email sent to ${to} with subject "${subject}"`);


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added a templated feedback email and support for optional screenshot attachments to improve review and triage. Increased request body limits to 5 MB.

- **New Features**
  - Render feedback emails using FeedbackNotificationEmail with feedback and type.
  - Accept a base64 JPEG screenshot and send it as an attachment (screenshot.jpeg).
  - API now expects { feedback, type, screenshot? }; controller forwards the full payload to the job.
  - Validation adds a type enum and ensures screenshot is a JPEG data URL.
  - Mail service and worker handle attachments; env config used for Resend keys and sender.

- **Migration**
  - Client should send payload: feedback (string), type ("Problemas" | "Ideias" | "Outros"), screenshot? as data:image/jpeg;base64,...
  - Keep screenshots under ~5 MB to fit the new body limits.

<sup>Written for commit dc28747397b7faad1af80c496e45abffbfedbb17. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

