### PR TITLE
feat(web): add screenshot button in feedback popover

### DIFF
--- a/.changeset/wild-tools-tie.md
+++ b/.changeset/wild-tools-tie.md
@@ -1,0 +1,5 @@
+---
+"web": minor
+---
+
+add screenshot button in feedback popover

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -23,6 +23,7 @@
 		"@vee-validate/nuxt": "5.0.0-beta.0",
 		"@vueuse/core": "14.1.0",
 		"better-auth": "1.4.13",
+		"html-to-image": "1.11.13",
 		"nuxt": "3.20.2",
 		"pinia": "3.0.4",
 		"vue": "3.5.26",

--- a/apps/frontend/src/components/Feedback/FeedbackForm.vue
+++ b/apps/frontend/src/components/Feedback/FeedbackForm.vue
@@ -2,54 +2,86 @@
 	<form class="feedback-form" @submit.prevent="onSubmit">
 		<textarea
 			v-model="feedback"
-			name="feedback"
 			v-bind="feedbackAttrs"
 			class="feedback-textarea"
-			:placeholder="steps[currentStep]?.placeholder || ''"
+			:placeholder="steps[currentStep].placeholder"
 			rows="5"
 			:class="{ 'field-error': errors.feedback }"
 			autofocus
 		></textarea>
-		<span class="error">{{ errors.feedback }}</span>
-		<button class="btn btn--submit" type="submit" :disabled="!meta.valid">
-			<template v-if="!isSubmitting">Enviar</template>
-			<template v-else>
-				<AppLoading />
-			</template>
-		</button>
+		<span v-if="errors.feedback" class="error">{{ errors.feedback }}</span>
+		<span v-if="errors.screenshot" class="error">{{ errors.screenshot }}</span>
+		<div class="feedback-footer">
+			<ScreenshotButton @screenshot="screenshot = $event" />
+			<button class="btn btn--submit" type="submit" :disabled="!meta.valid">
+				<template v-if="!isSubmitting">Enviar</template>
+				<template v-else>
+					<AppLoading />
+				</template>
+			</button>
+		</div>
 	</form>
 </template>
 
 <script setup lang="ts">
 import type { FeedbackForm } from '@/types/FeedbackForm'
+import ScreenshotButton from '@components/Feedback/screenshot-button.vue'
 import useCurrentStep from '@composables/Feedback/useCurrentStep'
 import useSetStep from '@composables/Feedback/useSetStep'
 import useSteps from '@composables/Feedback/useSteps'
+import feedbackService from '@services/feedback.service'
 import { feedbackZodSchema } from '@validations/feedback.validation'
+import { toast } from 'vue-sonner'
+
+type FormFields = keyof (typeof feedbackZodSchema)['shape']
+
+type FetchError<T> = {
+	data: { message: string; errors?: Array<{ path: T; message: string; code: string }> }
+}
 
 const currentStep = useCurrentStep()
 const steps = useSteps()
 const setStep = useSetStep
 const { errors, setFieldError, meta, handleSubmit, isSubmitting, defineField } = useForm({
-	validationSchema: feedbackZodSchema
+	validationSchema: feedbackZodSchema,
+	initialValues: {
+		type: steps.value[currentStep.value].title
+	}
 })
 const [feedback, feedbackAttrs] = defineField('feedback')
-const config = useRuntimeConfig()
+const screenshot = ref<string | null>(null)
 
-const onSubmit = handleSubmit(async ({ feedback }: FeedbackForm) => {
+const onSubmit = handleSubmit(async (values) => {
+	const payload: FeedbackForm = { ...values }
+
+	if (screenshot.value) payload.screenshot = screenshot.value
+
 	try {
-		await $fetch(`${config.public.apiUrl}/feedback`, {
-			method: 'POST',
-			headers: {
-				'Content-Type': 'application/json'
-			},
-			body: { feedback }
-		})
+		await feedbackService(payload)
 
 		setStep(steps.value.length)
-	} catch (error) {
-		console.error('Erro ao enviar feedback:', error)
-		setFieldError('feedback', 'Ocorreu um erro ao enviar o feedback.')
+	} catch (err) {
+		console.error('Erro ao enviar feedback:', err)
+		const error = err as FetchError<FormFields>
+
+		const data = error.data
+
+		if (!data) {
+			toast.error('Ocorreu um erro ao enviar o feedback. Tente novamente mais tarde.')
+			return
+		}
+
+		console.log(error.data)
+
+		if (data.message) {
+			toast.error(data.message)
+		}
+
+		if (data.errors) {
+			data.errors.forEach((err) => {
+				setFieldError(err.path, err.message)
+			})
+		}
 	}
 })
 </script>
@@ -67,7 +99,7 @@ const onSubmit = handleSubmit(async ({ feedback }: FeedbackForm) => {
 		}
 
 		.error {
-			color: #d32f2f;
+			color: #ef4444;
 			font: 700 1.2rem / 1.6 $font-body;
 			margin-top: -1rem;
 			padding-left: 0.4rem;
@@ -92,6 +124,18 @@ const onSubmit = handleSubmit(async ({ feedback }: FeedbackForm) => {
 		&:focus {
 			border-color: #ff7f00;
 		}
+	}
+
+	&-footer {
+		display: flex;
+		justify-content: flex-end;
+		gap: 0.8rem;
+	}
+}
+
+.btn {
+	&--submit {
+		flex: 1;
 	}
 }
 </style>

--- a/apps/frontend/src/components/Feedback/screenshot-button.vue
+++ b/apps/frontend/src/components/Feedback/screenshot-button.vue
@@ -1,0 +1,97 @@
+<script setup lang="ts">
+import useIsTakingScreenshot from '@composables/Feedback/useIsTakingScreenshot'
+import { toJpeg } from 'html-to-image'
+
+const emit = defineEmits<(e: 'screenshot', dataURL: string) => void>()
+const { isTakingScreenshot, setIsTakingScreenshot } = useIsTakingScreenshot()
+const dataUrl = ref<string | null>(null)
+const { setErrors } = useField('screenshot')
+
+async function handleTakeScreenshot() {
+	setIsTakingScreenshot(true)
+	const screenshotTarget = document.documentElement
+
+	try {
+		dataUrl.value = await toJpeg(screenshotTarget, {
+			cacheBust: true,
+			quality: 0.7,
+			pixelRatio: 2,
+			width: window.innerWidth,
+			height: window.innerHeight,
+			style: {
+				transform: `translateY(-${window.scrollY}px)`,
+				width: `${window.innerWidth}px`,
+				height: `${window.innerHeight}px`
+			},
+			filter: (node) => {
+				if (node.nodeType !== 1) return true
+				const isPopover = node.classList.contains('feedback-widget')
+
+				return !isPopover
+			}
+		})
+
+		const MAX_SIZE_MB = 5
+		const sizeInBytes = dataUrl.value.length * (3 / 4)
+		const sizeInMB = sizeInBytes / (1024 * 1024)
+
+		if (sizeInMB > MAX_SIZE_MB) {
+			dataUrl.value = null
+			setErrors(`Print excedeu o limite de ${MAX_SIZE_MB}MB.`)
+			return
+		}
+
+		if (dataUrl.value) emit('screenshot', dataUrl.value)
+	} finally {
+		setIsTakingScreenshot(false)
+	}
+}
+</script>
+<template>
+	<template v-if="dataUrl">
+		<button
+			class="btn btn--trash"
+			type="button"
+			:style="{ backgroundImage: `url(${dataUrl})` }"
+			@click="dataUrl = null"
+		>
+			<Icon name="material-symbols:delete" size="16" style="color: #000000" />
+		</button>
+	</template>
+	<template v-else>
+		<button class="btn btn--screenshot" type="button" @click="handleTakeScreenshot">
+			<template v-if="isTakingScreenshot">
+				<AppLoading />
+			</template>
+			<template v-else>
+				<Icon name="material-symbols:android-camera-outline" size="24" />
+			</template>
+		</button>
+	</template>
+</template>
+<style scoped lang="scss">
+.btn {
+	border-radius: 0.8rem;
+
+	&--screenshot,
+	&--trash {
+		width: 4rem;
+		height: 4rem;
+	}
+
+	&--screenshot {
+		&:hover {
+			background-color: #304986;
+		}
+	}
+
+	&--trash {
+		background-repeat: no-repeat;
+		background-position: center;
+		background-size: cover;
+		display: flex;
+		justify-content: end;
+		align-items: end;
+	}
+}
+</style>

--- a/apps/frontend/src/composables/Feedback/useIsTakingScreenshot.ts
+++ b/apps/frontend/src/composables/Feedback/useIsTakingScreenshot.ts
@@ -1,0 +1,14 @@
+import { storeToRefs } from 'pinia'
+
+const useIsTakingScreenshot = () => {
+	const store = useFeedbackStore()
+	const { isTakingScreenshot } = storeToRefs(store)
+	const setIsTakingScreenshot = (value: boolean) => store.setIsTakingScreenshot(value)
+
+	return {
+		isTakingScreenshot: readonly(isTakingScreenshot),
+		setIsTakingScreenshot
+	}
+}
+
+export default useIsTakingScreenshot

--- a/apps/frontend/src/services/feedback.service.ts
+++ b/apps/frontend/src/services/feedback.service.ts
@@ -1,0 +1,13 @@
+import type { FeedbackForm } from '@/types/FeedbackForm'
+
+export default async function feedbackService(payload: FeedbackForm) {
+	const { apiUrl } = useRuntimeConfig().public
+
+	return await $fetch(`${apiUrl}/feedback`, {
+		method: 'POST',
+		headers: {
+			'Content-Type': 'application/json'
+		},
+		body: payload
+	})
+}

--- a/apps/frontend/src/stores/feedback.ts
+++ b/apps/frontend/src/stores/feedback.ts
@@ -4,6 +4,7 @@ import { defineStore } from 'pinia'
 export const useFeedbackStore = defineStore('feedback', {
 	state: () => ({
 		isOpen: false,
+		isTakingScreenshot: false,
 		currentStep: -1,
 		steps: feedbackOptions
 	}),
@@ -17,6 +18,9 @@ export const useFeedbackStore = defineStore('feedback', {
 		},
 		resetStep() {
 			this.currentStep = -1
+		},
+		setIsTakingScreenshot(val: boolean) {
+			this.isTakingScreenshot = val
 		}
 	}
 })

--- a/apps/frontend/src/types/FeedbackForm.ts
+++ b/apps/frontend/src/types/FeedbackForm.ts
@@ -1,4 +1,4 @@
-import type { feedbackZodSchema } from '@schemas/feedback'
+import type { feedbackZodSchema } from '@validations/feedback.validation'
 import type { z } from 'zod'
 
 export type FeedbackForm = z.infer<typeof feedbackZodSchema>

--- a/apps/frontend/src/types/FeedbackOption.ts
+++ b/apps/frontend/src/types/FeedbackOption.ts
@@ -1,5 +1,7 @@
+import type { FeedbackType } from '@validations/feedback.validation'
+
 export default interface FeedbackOption {
-	title: string
+	title: FeedbackType
 	icon: string
 	color: string
 	placeholder: string

--- a/apps/frontend/src/validations/feedback.validation.ts
+++ b/apps/frontend/src/validations/feedback.validation.ts
@@ -1,7 +1,16 @@
 import { z } from 'zod'
 
+export const FeedbackTypeEnum = z.enum(['Problemas', 'Ideias', 'Outros'])
+export type FeedbackType = z.infer<typeof FeedbackTypeEnum>
+
 export const feedbackZodSchema = z.object({
-	feedback: z
-		.string({ error: '*Preencha esse campo' })
-		.nonempty({ message: '*Preencha esse campo' })
+	feedback: z.string({ error: '*Preencha esse campo' }).nonempty({ error: '*Preencha esse campo' }),
+	type: FeedbackTypeEnum,
+	screenshot: z
+		.string()
+		.optional()
+		.refine(
+			(value) => !value || value.startsWith('data:image/jpeg;base64,'),
+			'Print deve ser uma imagem JPEG'
+		)
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,6 +111,9 @@ importers:
       better-auth:
         specifier: 1.4.13
         version: 1.4.13(drizzle-kit@0.31.8)(drizzle-orm@0.45.1(@types/pg@8.16.0)(kysely@0.28.10)(pg@8.17.1))(next@16.0.11(@babel/core@7.28.6)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.97.2))(pg@8.17.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vitest@3.2.4(@types/node@25.2.1)(happy-dom@17.6.3)(jiti@2.6.1)(lightningcss@1.31.0)(sass-embedded@1.97.2)(sass@1.97.2)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vue@3.5.26(typescript@5.9.3))
+      html-to-image:
+        specifier: 1.11.13
+        version: 1.11.13
       nuxt:
         specifier: 3.20.2
         version: 3.20.2(@biomejs/biome@2.3.11)(@parcel/watcher@2.5.4)(@types/node@25.2.1)(@vue/compiler-sfc@3.5.27)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4(drizzle-orm@0.45.1(@types/pg@8.16.0)(kysely@0.28.10)(pg@8.17.1)))(drizzle-orm@0.45.1(@types/pg@8.16.0)(kysely@0.28.10)(pg@8.17.1))(eslint@9.39.2(jiti@2.6.1))(ioredis@5.9.1)(lightningcss@1.31.0)(magicast@0.5.1)(optionator@0.9.4)(rollup@4.55.2)(sass-embedded@1.97.2)(sass@1.97.2)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.2.1)(jiti@2.6.1)(lightningcss@1.31.0)(sass-embedded@1.97.2)(sass@1.97.2)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(yaml@2.8.2)
@@ -5796,6 +5799,9 @@ packages:
 
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+
+  html-to-image@1.11.13:
+    resolution: {integrity: sha512-cuOPoI7WApyhBElTTb9oqsawRvZ0rHhaHwghRLlTuffoD1B2aDemlCruLeZrUIIdvG7gs9xeELEPm6PhuASqrg==}
 
   html-to-text@9.0.5:
     resolution: {integrity: sha512-qY60FjREgVZL03vJU6IfMV4GDjGBIoOyvuFdpBDIX9yTlDw0TjxVBQp+P8NvpdIXNJvfWBTNul7fsAQJq2FNpg==}
@@ -12718,7 +12724,7 @@ snapshots:
 
   '@types/pg@8.16.0':
     dependencies:
-      '@types/node': 25.0.9
+      '@types/node': 25.2.1
       pg-protocol: 1.11.0
       pg-types: 2.2.0
 
@@ -15385,6 +15391,8 @@ snapshots:
   html-entities@2.6.0: {}
 
   html-escaper@2.0.2: {}
+
+  html-to-image@1.11.13: {}
 
   html-to-text@9.0.5:
     dependencies:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a screenshot button to the feedback popover so users can capture and attach a JPEG to their feedback. Improves validation and error handling, and sends screenshot and feedback type to the API.

- **New Features**
  - Add screenshot capture (full page, excludes widget), JPEG only, 5MB limit, preview with remove, and loading state.
  - Add Zod validation for feedback type and optional screenshot; show per-field errors from API and UI.
  - Send { feedback, type, screenshot } via new feedbackService; prefill type from the selected step.
  - Add Pinia state (isTakingScreenshot) and composable for capture state; minor UI tweaks to footer and error color.

- **Dependencies**
  - Add html-to-image@1.11.13 for screenshot generation.

<sup>Written for commit 35a56d266afb1591aec07a479319d9d7e6479301. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

