### PR TITLE
fix(web): update copyright year range in AppFooter

### DIFF
--- a/.changeset/busy-toys-tap.md
+++ b/.changeset/busy-toys-tap.md
@@ -1,0 +1,5 @@
+---
+"web": patch
+---
+
+update copyright year range in AppFooter

--- a/apps/frontend/src/components/AppFooter.vue
+++ b/apps/frontend/src/components/AppFooter.vue
@@ -18,7 +18,7 @@
 					</section>
 				</div>
 				<section class="footer__copyright" aria-label="copyright">
-					© {{ currentYear }} Receitas de Crochê. Todos os direitos reservados.
+					© 2025 - {{ currentYear }} Receitas de Crochê. Todos os direitos reservados.
 				</section>
 			</div>
 		</AppContainer>

--- a/apps/frontend/src/tests/components/AppFooter.test.ts
+++ b/apps/frontend/src/tests/components/AppFooter.test.ts
@@ -32,7 +32,7 @@ describe('AppFooter.vue', () => {
 
 		expect(description.exists()).toBe(true)
 		expect(description.text()).toBe(
-			`© ${currentYear} Receitas de Crochê. Todos os direitos reservados.`
+			`© 2025 - ${currentYear} Receitas de Crochê. Todos os direitos reservados.`
 		)
 	})
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update AppFooter to display a copyright year range "© 2025 - {currentYear}" instead of a single year, so the footer reflects the site launch year through the current year. Updated the unit test to assert the new format.

<sup>Written for commit e25dd437853b7bef0f0f6d345148464ad0aee927. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

