### PR TITLE
fix(transactional): update copyright year range in footer-email template

### DIFF
--- a/.changeset/tiny-lies-cry.md
+++ b/.changeset/tiny-lies-cry.md
@@ -1,0 +1,5 @@
+---
+"@rdc/transactional": patch
+---
+
+update copyright year range in footer-email template

--- a/packages/transactional/emails/components/footer-email.tsx
+++ b/packages/transactional/emails/components/footer-email.tsx
@@ -2,7 +2,7 @@ import { Container, Hr, Section, Text } from "@react-email/components";
 // biome-ignore lint/correctness/noUnusedImports: This import is required for the compiler to recognize the file as a .tsx React file.
 import * as React from "react";
 
-const fullYear = new Date().getFullYear();
+const currentYear = new Date().getFullYear();
 
 const hr = {
 	borderColor: "#e5e5e5",
@@ -26,7 +26,8 @@ export default function FooterEmail() {
 			<Hr style={hr} />
 			<Section style={footer}>
 				<Text style={footerSmall}>
-					© {fullYear} Receitas de Crochê. Todos os direitos reservados.
+					© 2025 - {currentYear} Receitas de Crochê. Todos os direitos
+					reservados.
 				</Text>
 				<Text style={footerSmall}>
 					Você está recebendo este email porque solicitou a redefinição de


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updates the transactional email footer to show a year range (© 2025 - current year) instead of a single year. This keeps the copyright accurate going forward without manual updates.

<sup>Written for commit 65830538172761130659e875c79d33086f6370c1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

