### PR TITLE
refactor(backend): migrate to official @better-auth/redis-storage in better-auth

### DIFF
--- a/.changeset/hungry-parrots-share.md
+++ b/.changeset/hungry-parrots-share.md
@@ -1,0 +1,5 @@
+---
+"backend": patch
+---
+
+refactor(auth): migrate to official @better-auth/redis-storage

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -20,6 +20,7 @@
 		"db:studio": "drizzle-kit studio --config src/config/drizzle-kit.config.ts --host 0.0.0.0 --verbose"
 	},
 	"dependencies": {
+		"@better-auth/redis-storage": "1.5.3",
 		"@rdc/transactional": "workspace:*",
 		"@react-email/render": "2.0.4",
 		"better-auth": "1.4.13",

--- a/apps/backend/src/config/better-auth.config.ts
+++ b/apps/backend/src/config/better-auth.config.ts
@@ -10,21 +10,24 @@ import { drizzleAdapter } from "better-auth/adapters/drizzle";
 import { jwt, openAPI } from "better-auth/plugins";
 import { localization } from "better-auth-localization";
 
+const isSecure =
+	env.NODE_ENV === "production" || env.BETTER_AUTH_URL.startsWith("https://");
+
 export const auth = betterAuth({
 	trustedOrigins: [env.FRONTEND_URL],
-	...(env.NODE_ENV === "production" && {
-		advanced: {
-			useSecureCookies: true,
-			defaultCookieAttributes: {
-				secure: true,
-				sameSite: "None",
-			},
-			crossSubDomainCookies: {
-				enabled: true,
-				domain: new URL(env.FRONTEND_URL).hostname,
-			},
+	advanced: {
+		useSecureCookies: isSecure,
+		defaultCookieAttributes: {
+			secure: isSecure,
+			sameSite: isSecure ? "none" : "lax",
 		},
-	}),
+		crossSubDomainCookies: {
+			enabled:
+				env.NODE_ENV === "production" &&
+				!env.FRONTEND_URL.includes("localhost"),
+			domain: new URL(env.FRONTEND_URL).hostname,
+		},
+	},
 	database: drizzleAdapter(db, {
 		provider: "pg",
 		usePlural: true,

--- a/apps/backend/src/config/better-auth.config.ts
+++ b/apps/backend/src/config/better-auth.config.ts
@@ -1,6 +1,6 @@
+import { redisStorage } from "@better-auth/redis-storage";
 import { env } from "@config/env.config.ts";
 import redisConnection from "@config/redis.ts";
-import { SESSION_AUTH_PREFIX } from "@constants/auth.constant.ts";
 import db from "@db/index.ts";
 import { PasswordResetEmail } from "@rdc/transactional";
 import { render } from "@react-email/render";
@@ -32,24 +32,10 @@ export const auth = betterAuth({
 		provider: "pg",
 		usePlural: true,
 	}),
-	secondaryStorage: {
-		get: async (key) => {
-			return await redisConnection.get(`${SESSION_AUTH_PREFIX}${key}`);
-		},
-		set: async (key, value, ttl) => {
-			if (ttl)
-				await redisConnection.set(
-					`${SESSION_AUTH_PREFIX}${key}`,
-					value,
-					"EX",
-					ttl,
-				);
-			else await redisConnection.set(`${SESSION_AUTH_PREFIX}${key}`, value);
-		},
-		delete: async (key) => {
-			await redisConnection.del(`${SESSION_AUTH_PREFIX}${key}`);
-		},
-	},
+	secondaryStorage: redisStorage({
+		client: redisConnection,
+		keyPrefix: "auth:session:",
+	}),
 	baseURL: env.BETTER_AUTH_URL,
 	basePath: "/auth",
 	plugins: [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
 
   apps/backend:
     dependencies:
+      '@better-auth/redis-storage':
+        specifier: 1.5.3
+        version: 1.5.3(@better-auth/core@1.4.13(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.7(zod@4.3.5))(jose@6.1.3)(kysely@0.28.10)(nanostores@1.1.0))(ioredis@5.9.1)
       '@rdc/transactional':
         specifier: workspace:*
         version: link:../../packages/transactional
@@ -848,6 +851,12 @@ packages:
       jose: ^6.1.0
       kysely: ^0.28.5
       nanostores: ^1.0.1
+
+  '@better-auth/redis-storage@1.5.3':
+    resolution: {integrity: sha512-UmCGGezeYTxMLgxo55mee2T2zg2shV6tJqxHZS04YFH+YgO5wHcA/YLERfAOXpqpoLO5UGyoLzWXHs2+2VYgfA==}
+    peerDependencies:
+      '@better-auth/core': 1.5.3
+      ioredis: ^5.0.0
 
   '@better-auth/telemetry@1.4.13':
     resolution: {integrity: sha512-bH77Scx0K0lRIuRuHUUBLLMJ/rd9T2Tties1RniDLU8kclVwjboJQbfUY5FIamZwdayf2o0psNgS4rkaZUq+Qg==}
@@ -9919,6 +9928,11 @@ snapshots:
       kysely: 0.28.10
       nanostores: 1.1.0
       zod: 4.3.5
+
+  '@better-auth/redis-storage@1.5.3(@better-auth/core@1.4.13(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.7(zod@4.3.5))(jose@6.1.3)(kysely@0.28.10)(nanostores@1.1.0))(ioredis@5.9.1)':
+    dependencies:
+      '@better-auth/core': 1.4.13(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.7(zod@4.3.5))(jose@6.1.3)(kysely@0.28.10)(nanostores@1.1.0)
+      ioredis: 5.9.1
 
   '@better-auth/telemetry@1.4.13(@better-auth/core@1.4.13(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.7(zod@4.3.5))(jose@6.1.3)(kysely@0.28.10)(nanostores@1.1.0))':
     dependencies:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Migrated BetterAuth secondary storage to the official @better-auth/redis-storage and made cookie settings environment-aware to improve session reliability across environments and subdomains.

- **Refactors**
  - Replaced custom Redis secondaryStorage with redisStorage using our Redis client and keyPrefix "auth:session:".
  - Added isSecure logic (based on NODE_ENV or HTTPS URL) to set secure and sameSite cookies appropriately.
  - Enabled cross-subdomain cookies only in production and non-localhost, using FRONTEND_URL hostname.

- **Dependencies**
  - Added @better-auth/redis-storage@1.5.3.

<sup>Written for commit d6c7950ffd98440fad1397253b1bed7216df83a1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

