### PR TITLE
fix(backend): wrap products response in data envelope

### DIFF
--- a/.changeset/true-pets-visit.md
+++ b/.changeset/true-pets-visit.md
@@ -1,0 +1,5 @@
+---
+"backend": patch
+---
+
+wrap products response in data envelope

--- a/apps/backend/src/controllers/product.controller.ts
+++ b/apps/backend/src/controllers/product.controller.ts
@@ -2,5 +2,5 @@ import products from "@utils/data/products.ts";
 import type { Request, Response } from "express";
 
 export const getAllProducts = async (_req: Request, res: Response) => {
-	res.json(products);
+	res.json({ data: products });
 };


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
GET `/products` now returns `{ data: products }` instead of a raw array to match our API contract and prevent client parsing errors.

<sup>Written for commit d22699c6263dab894c92c737410f0ed48d89fd41. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

