### PR TITLE
fix(web): consume products from API data envelope

### DIFF
--- a/.changeset/major-games-melt.md
+++ b/.changeset/major-games-melt.md
@@ -1,0 +1,5 @@
+---
+"web": patch
+---
+
+consume products from API data envelope

--- a/apps/frontend/src/components/ProductTile.vue
+++ b/apps/frontend/src/components/ProductTile.vue
@@ -46,9 +46,10 @@ const config = useRuntimeConfig()
 const whatsAppSales = config.public.whatsAppSales
 const gtm = useGtm()
 
-const { data: products, pending } = await useFetch<Product[]>(`${config.public.apiUrl}/products`, {
+const { data: products, pending } = await useFetch(`${config.public.apiUrl}/products`, {
 	key: 'products',
-	lazy: true
+	lazy: true,
+	transform: (res: { data: Product[] }) => res.data
 })
 
 function handleWhatsAppClick(product: Product) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update `ProductTile.vue` to read products from the API’s `{ data: Product[] }` envelope using `useFetch` with a `transform` to `res.data`. This aligns with the backend response and prevents broken or empty product lists.

<sup>Written for commit 0bf2edb4c4adaa44160e8337e8e624f81cd49358. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

