### PR TITLE
refactor(backend): add drizzle snake case casing

### DIFF
--- a/.changeset/modern-wasps-help.md
+++ b/.changeset/modern-wasps-help.md
@@ -1,0 +1,5 @@
+---
+"backend": patch
+---
+
+implement automatic snake_case naming convention across all schemas

--- a/apps/backend/src/config/drizzle-kit.config.ts
+++ b/apps/backend/src/config/drizzle-kit.config.ts
@@ -16,4 +16,5 @@ export default defineConfig({
 	migrations: {
 		schema: "public",
 	},
+	casing: "snake_case",
 });

--- a/apps/backend/src/db/index.ts
+++ b/apps/backend/src/db/index.ts
@@ -12,6 +12,7 @@ const clientPostgres = postgres({
 	password: env.DB_PASSWORD,
 	database: env.DB_DATABASE,
 });
-const db = drizzle(clientPostgres, { schema });
+
+const db = drizzle(clientPostgres, { schema, casing: "snake_case" });
 
 export default db;

--- a/apps/backend/src/db/migrations/0001_enable_snake_case_casing.sql
+++ b/apps/backend/src/db/migrations/0001_enable_snake_case_casing.sql
@@ -1,0 +1,4 @@
+ALTER TABLE "users" DROP CONSTRAINT "users_public_id_unique";--> statement-breakpoint
+DROP INDEX "accounts_userId_idx";--> statement-breakpoint
+CREATE INDEX "accounts_user_id_idx" ON "accounts" USING btree ("user_id");--> statement-breakpoint
+ALTER TABLE "users" ADD CONSTRAINT "users_publicId_unique" UNIQUE("public_id");

--- a/apps/backend/src/db/migrations/meta/0001_snapshot.json
+++ b/apps/backend/src/db/migrations/meta/0001_snapshot.json
@@ -1,0 +1,349 @@
+{
+  "id": "90a736b6-0939-4fa6-b87c-b917024624cf",
+  "prevId": "1ed0db4b-784e-4d77-a124-5e8dfc5273c8",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "accounts_user_id_idx": {
+          "name": "accounts_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.jwks": {
+      "name": "jwks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "public_id": {
+          "name": "public_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_publicId_unique": {
+          "name": "users_publicId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "public_id"
+          ]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verifications": {
+      "name": "verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "verifications_identifier_idx": {
+          "name": "verifications_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/backend/src/db/migrations/meta/_journal.json
+++ b/apps/backend/src/db/migrations/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1771193104761,
       "tag": "0000_create_users_and_auth_tables",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1775149991281,
+      "tag": "0001_enable_snake_case_casing",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/backend/src/db/schemas/accounts.schema.ts
+++ b/apps/backend/src/db/schemas/accounts.schema.ts
@@ -6,26 +6,26 @@ import { index, pgTable, text, timestamp } from "drizzle-orm/pg-core";
 export const accounts = pgTable(
 	"accounts",
 	{
-		id: text("id").primaryKey(),
-		accountId: text("account_id").notNull(),
-		providerId: text("provider_id").notNull(),
-		userId: text("user_id")
+		id: text().primaryKey(),
+		accountId: text().notNull(),
+		providerId: text().notNull(),
+		userId: text()
 			.notNull()
 			.references(() => users.id, { onDelete: "cascade" }),
-		accessToken: text("access_token"),
-		refreshToken: text("refresh_token"),
-		idToken: text("id_token"),
-		accessTokenExpiresAt: timestamp("access_token_expires_at", {
+		accessToken: text(),
+		refreshToken: text(),
+		idToken: text(),
+		accessTokenExpiresAt: timestamp({
 			withTimezone: true,
 		}),
-		refreshTokenExpiresAt: timestamp("refresh_token_expires_at", {
+		refreshTokenExpiresAt: timestamp({
 			withTimezone: true,
 		}),
-		scope: text("scope"),
-		password: text("password"),
+		scope: text(),
+		password: text(),
 		...timestamps,
 	},
-	(table) => [index("accounts_userId_idx").on(table.userId)],
+	(table) => [index("accounts_user_id_idx").on(table.userId)],
 );
 
 export const accountsRelations = relations(accounts, ({ one }) => ({

--- a/apps/backend/src/db/schemas/jwks.schema.ts
+++ b/apps/backend/src/db/schemas/jwks.schema.ts
@@ -1,9 +1,9 @@
 import { pgTable, text, timestamp } from "drizzle-orm/pg-core";
 
 export const jwks = pgTable("jwks", {
-	id: text("id").primaryKey(),
-	publicKey: text("public_key").notNull(),
-	privateKey: text("private_key").notNull(),
-	createdAt: timestamp("created_at", { withTimezone: true }).notNull(),
-	expiresAt: timestamp("expires_at", { withTimezone: true }),
+	id: text().primaryKey(),
+	publicKey: text().notNull(),
+	privateKey: text().notNull(),
+	createdAt: timestamp({ withTimezone: true }).notNull(),
+	expiresAt: timestamp({ withTimezone: true }),
 });

--- a/apps/backend/src/db/schemas/users.schema.ts
+++ b/apps/backend/src/db/schemas/users.schema.ts
@@ -5,15 +5,15 @@ import { boolean, pgTable, text, uuid } from "drizzle-orm/pg-core";
 import { v7 as uuidv7 } from "uuid";
 
 export const users = pgTable("users", {
-	id: text("id").primaryKey(),
-	publicId: uuid("public_id")
+	id: text().primaryKey(),
+	publicId: uuid()
 		.$defaultFn(() => uuidv7())
 		.notNull()
 		.unique(),
-	name: text("name").notNull(),
-	email: text("email").notNull().unique(),
-	emailVerified: boolean("email_verified").default(false).notNull(),
-	image: text("image"),
+	name: text().notNull(),
+	email: text().notNull().unique(),
+	emailVerified: boolean().default(false).notNull(),
+	image: text(),
 	...timestamps,
 });
 

--- a/apps/backend/src/db/schemas/verifications.schema.ts
+++ b/apps/backend/src/db/schemas/verifications.schema.ts
@@ -4,10 +4,10 @@ import { index, pgTable, text, timestamp } from "drizzle-orm/pg-core";
 export const verifications = pgTable(
 	"verifications",
 	{
-		id: text("id").primaryKey(),
-		identifier: text("identifier").notNull(),
-		value: text("value").notNull(),
-		expiresAt: timestamp("expires_at", { withTimezone: true }).notNull(),
+		id: text().primaryKey(),
+		identifier: text().notNull(),
+		value: text().notNull(),
+		expiresAt: timestamp({ withTimezone: true }).notNull(),
 		...timestamps,
 	},
 	(table) => [index("verifications_identifier_idx").on(table.identifier)],


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switches the backend DB to automatic snake_case naming using `drizzle-orm` and `drizzle-kit`. This standardizes column, index, and constraint names and removes manual column mapping in schemas.

- **Refactors**
  - Enabled `casing: "snake_case"` in `drizzle-kit` config and the `drizzle-orm` client.
  - Simplified `users`, `accounts`, `jwks`, and `verifications` schemas to rely on automatic casing (no explicit column names).

- **Migration**
  - Apply `0001_enable_snake_case_casing` to align indexes/constraints with snake_case (drops `accounts_userId_idx` → creates `accounts_user_id_idx`; replaces `users_public_id_unique` → `users_publicId_unique`).
  - Run the migration; no app code changes required.

<sup>Written for commit 03c7e7d7a238ad2e53364cb5fceed871662715b2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

