### PR TITLE
chore(backend): add tsconfig base setup

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -39,6 +39,7 @@
 	},
 	"devDependencies": {
 		"@biomejs/biome": "2.3.11",
+		"@tsconfig/node22": "22.0.5",
 		"@types/cors": "2.8.19",
 		"@types/express": "5.0.6",
 		"@types/pg": "8.16.0",

--- a/apps/backend/tsconfig.json
+++ b/apps/backend/tsconfig.json
@@ -1,17 +1,13 @@
 {
+	"extends": "@tsconfig/node22/tsconfig.json",
 	"compilerOptions": {
-		"target": "ES2023",
-		"module": "node20",
-		"lib": ["ES2023"],
 		"outDir": "./dist",
 		"rootDir": "./src",
-		"strict": true,
-		"esModuleInterop": true,
-		"skipLibCheck": true,
 		"forceConsistentCasingInFileNames": true,
 		"noEmit": true,
 		"allowImportingTsExtensions": true,
 		"baseUrl": "./src",
+		"ignoreDeprecations": "6.0",
 		"paths": {
 			"@routes/*": ["routes/*"],
 			"@middlewares/*": ["middlewares/*"],

--- a/apps/frontend/nuxt.config.ts
+++ b/apps/frontend/nuxt.config.ts
@@ -76,6 +76,7 @@ export default defineNuxtConfig({
 	alias: {
 		'@components': fileURLToPath(new URL('./src/components', import.meta.url)),
 		'@composables': fileURLToPath(new URL('./src/composables', import.meta.url)),
+		'@constants': fileURLToPath(new URL('./src/constants', import.meta.url)),
 		'@validations': fileURLToPath(new URL('./src/validations', import.meta.url)),
 		'@interfaces': fileURLToPath(new URL('./src/interfaces', import.meta.url)),
 		'@services': fileURLToPath(new URL('./src/services', import.meta.url)),

--- a/apps/frontend/tsconfig.json
+++ b/apps/frontend/tsconfig.json
@@ -5,6 +5,7 @@
 		"paths": {
 			"@components/*": ["components/*"],
 			"@composables/*": ["composables/*"],
+			"@constants/*": ["constants/*"],
 			"@validations/*": ["validations/*"],
 			"@interfaces/*": ["interfaces/*"],
 			"@services/*": ["services/*"],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,6 +66,9 @@ importers:
       '@biomejs/biome':
         specifier: 2.3.11
         version: 2.3.11
+      '@tsconfig/node22':
+        specifier: 22.0.5
+        version: 22.0.5
       '@types/cors':
         specifier: 2.8.19
         version: 2.8.19
@@ -3357,6 +3360,9 @@ packages:
   '@trysound/sax@0.2.0':
     resolution: {integrity: sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==}
     engines: {node: '>=10.13.0'}
+
+  '@tsconfig/node22@22.0.5':
+    resolution: {integrity: sha512-hLf2ld+sYN/BtOJjHUWOk568dvjFQkHnLNa6zce25GIH+vxKfvTgm3qpaH6ToF5tu/NN0IH66s+Bb5wElHrLcw==}
 
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
@@ -12653,6 +12659,8 @@ snapshots:
 
   '@trysound/sax@0.2.0':
     optional: true
+
+  '@tsconfig/node22@22.0.5': {}
 
   '@tybys/wasm-util@0.10.1':
     dependencies:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Sets a shared base TS config for the backend using `@tsconfig/node22` and adds a new `@constants` import alias in the frontend. This standardizes Node 22 settings and simplifies imports.

- **Refactors**
  - Backend `tsconfig.json` now extends `@tsconfig/node22/tsconfig.json`; removed redundant compiler options and added `ignoreDeprecations: "6.0"`.
  - Frontend adds `@constants` alias in `nuxt.config.ts` and path mapping in `tsconfig.json`.

- **Dependencies**
  - Added `@tsconfig/node22@22.0.5` to dev dependencies.

<sup>Written for commit fd3cbb8ba5a37d430c76b2cd4424a52704ed7f83. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

